### PR TITLE
fix(image): 修复封面等地方的图片被错误设为表情类型，造成请求时丢失尺寸信息的问题，同时确保不设置圆角

### DIFF
--- a/lib/common/widgets/video_card/video_card_v.dart
+++ b/lib/common/widgets/video_card/video_card_v.dart
@@ -100,7 +100,7 @@ class VideoCardV extends StatelessWidget {
                             src: videoItem.cover,
                             width: maxWidth,
                             height: maxHeight,
-                            type: ImageType.emote,
+                            borderRadius: BorderRadius.zero, // 不传type，反而传radius来防止图片被重复加圆角
                           ),
                           if (videoItem.duration > 0)
                             PBadge(

--- a/lib/pages/live/widgets/live_item_app.dart
+++ b/lib/pages/live/widgets/live_item_app.dart
@@ -46,7 +46,7 @@ class LiveCardVApp extends StatelessWidget {
                         src: showFirstFrame ? item.systemCover : item.cover,
                         width: maxWidth,
                         height: maxHeight,
-                        type: ImageType.emote,
+                        borderRadius: BorderRadius.zero, // 不传type，反而传radius来防止图片被重复加圆角
                       ),
                       Positioned(
                         left: 0,

--- a/lib/pages/live_follow/widgets/live_item_follow.dart
+++ b/lib/pages/live_follow/widgets/live_item_follow.dart
@@ -44,7 +44,7 @@ class LiveCardVFollow extends StatelessWidget {
                         src: liveItem.roomCover!,
                         width: maxWidth,
                         height: maxHeight,
-                        type: ImageType.emote,
+                        borderRadius: BorderRadius.zero, // 不传type，反而传radius来防止图片被重复加圆角
                       ),
                       Positioned(
                         left: 0,

--- a/lib/pages/live_search/widgets/live_search_room.dart
+++ b/lib/pages/live_search/widgets/live_search_room.dart
@@ -2,7 +2,6 @@ import 'package:PiliPlus/common/constants.dart';
 import 'package:PiliPlus/common/widgets/flutter/layout_builder.dart';
 import 'package:PiliPlus/common/widgets/image/image_save.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
-import 'package:PiliPlus/models/common/image_type.dart';
 import 'package:PiliPlus/models_new/live/live_search/room_item.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
@@ -45,7 +44,7 @@ class LiveCardVSearch extends StatelessWidget {
                         src: item.cover!,
                         width: maxWidth,
                         height: maxHeight,
-                        type: ImageType.emote,
+                        borderRadius: BorderRadius.zero, // 不传type，反而传radius来防止图片被重复加圆角
                       ),
                       Positioned(
                         left: 0,

--- a/lib/pages/member_coin_arc/widgets/item.dart
+++ b/lib/pages/member_coin_arc/widgets/item.dart
@@ -72,7 +72,7 @@ class MemberCoinLikeItem extends StatelessWidget {
                         src: item.cover,
                         width: maxWidth,
                         height: maxHeight,
-                        type: ImageType.emote,
+                        borderRadius: BorderRadius.zero, // 不传type，反而传radius来防止图片被重复加圆角
                       ),
                       if (item.isCooperation == true)
                         const PBadge(

--- a/lib/pages/member_home/widgets/video_card_v_member_home.dart
+++ b/lib/pages/member_home/widgets/video_card_v_member_home.dart
@@ -93,7 +93,7 @@ class VideoCardVMemberHome extends StatelessWidget {
                         src: videoItem.cover,
                         width: maxWidth,
                         height: maxHeight,
-                        type: ImageType.emote,
+                        borderRadius: BorderRadius.zero, // 不传type，反而传radius来防止图片被重复加圆角
                       ),
                       if (videoItem.duration > 0)
                         PBadge(

--- a/lib/pages/search_panel/live/widgets/item.dart
+++ b/lib/pages/search_panel/live/widgets/item.dart
@@ -43,7 +43,7 @@ class LiveItem extends StatelessWidget {
                         src: liveItem.cover,
                         width: maxWidth,
                         height: maxHeight,
-                        type: ImageType.emote,
+                        borderRadius: BorderRadius.zero, // 不传type，反而传radius来防止图片被重复加圆角
                       ),
                       Positioned(
                         left: 0,

--- a/lib/pages/whisper_detail/widget/chat_item.dart
+++ b/lib/pages/whisper_detail/widget/chat_item.dart
@@ -440,7 +440,7 @@ class ChatItem extends StatelessWidget {
                     clipBehavior: Clip.none,
                     children: [
                       NetworkImgLayer(
-                        type: ImageType.emote,
+                        borderRadius: BorderRadius.zero, // 不传type，反而传radius来防止图片被重复加圆角
                         width: constrains.maxWidth,
                         height:
                             constrains.maxWidth / StyleString.aspectRatio16x9,


### PR DESCRIPTION
上游代码部分样式的图片错误的传参了ImageType.emote，导致处理图片url时将其当作表情包处理，根据组件显示尺寸获取缩略图的逻辑失效。该pr通过去除type传参并加上BorderRadius.zero（保证图片不会被默认裁切）来解决该问题。