### PR TITLE
fix(gesture): 修复鸿蒙下视频播放页横滑切换简介/评论区难以触发的问题

### DIFF
--- a/lib/common/widgets/gesture/horizontal_drag_gesture_recognizer.dart
+++ b/lib/common/widgets/gesture/horizontal_drag_gesture_recognizer.dart
@@ -62,5 +62,7 @@ bool _computeHitSlop(
 
 bool _calc(Offset initialPosition, Offset lastPosition) {
   final offset = lastPosition - initialPosition;
-  return offset.dx.abs() > offset.dy.abs() * 3;
+  // 判定：只要水平位移 > 垂直位移即算横滑（原为 dx > 3·dy，过于苛刻）。
+  // 约 45° 以内的滑动都会被判定为横向，让简介/评论区左右切换更容易触发。
+  return offset.dx.abs() > offset.dy.abs();
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,7 @@ import 'package:PiliPlus/utils/utils.dart';
 import 'package:catcher_2/catcher_2.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart' show DeviceGestureSettings;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
@@ -325,6 +326,14 @@ class MyApp extends StatelessWidget {
     final uiScale = ScaledWidgetsFlutterBinding.instance.scaleFactor;
     final mediaQuery = MediaQuery.of(context);
     final textScaler = TextScaler.linear(Pref.defaultTextScale);
+    // 鸿蒙 embedding（FlutterPage/FlutterView）把 ArkUI PanGesture 默认的
+    // 5(vp) 当 physicalTouchSlop 下发，框架除以 DPR 后竖向滚动的触发阈值
+    // 只有 ~1.5 逻辑像素（Android 约为 8）。竖向手势几乎瞬间赢得竞技场，
+    // 横向滑动（如简介/评论切换）无论怎么放宽都抢不到。此处恢复为
+    // Android 水平，使横竖手势能按主导方向公平竞争。
+    final gestureSettings = OS.isHarmony
+        ? const DeviceGestureSettings(touchSlop: 8)
+        : mediaQuery.gestureSettings;
     if (uiScale != 1.0) {
       child = MediaQuery(
         data: mediaQuery.copyWith(
@@ -334,12 +343,16 @@ class MyApp extends StatelessWidget {
           viewInsets: mediaQuery.viewInsets / uiScale,
           viewPadding: mediaQuery.viewPadding / uiScale,
           devicePixelRatio: mediaQuery.devicePixelRatio * uiScale,
+          gestureSettings: gestureSettings,
         ),
         child: child!,
       );
     } else {
       child = MediaQuery(
-        data: mediaQuery.copyWith(textScaler: textScaler),
+        data: mediaQuery.copyWith(
+          textScaler: textScaler,
+          gestureSettings: gestureSettings,
+        ),
         child: child!,
       );
     }

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -967,8 +967,10 @@ abstract final class Pref {
   static bool get showDynDispute =>
       _setting.get(SettingBoxKey.showDynDispute, defaultValue: false);
 
+  // 竖向滚动 slop 已在 main._builder 统一为 8 逻辑像素（鸿蒙），横向取 12
+  // 时约 34° 以内的滑动可赢得竞技场，横竖手势按主导方向竞争。
   static double get touchSlopH =>
-      _setting.get(SettingBoxKey.touchSlopH, defaultValue: 24.0);
+      _setting.get(SettingBoxKey.touchSlopH, defaultValue: 12.0);
 
   static bool get saveReply =>
       _setting.get(SettingBoxKey.saveReply, defaultValue: true);


### PR DESCRIPTION
## 问题
视频页左右滑动切换"简介/评论"标签页极难触发，绝大多数滑动被竖向滚动截获，只有近乎纯水平的滑动偶尔成功。

## 原因
鸿蒙 Flutter embedding（`FlutterPage`）把 ArkUI PanGesture 默认的5(vp) 当作 `physicalTouchSlop` 下发，框架除以 DPR 后**竖向滚动的触发阈值仅约 1.5 逻辑像素**（Android 约为 8）。竖向手势几乎瞬间赢得手势竞技场，横向手势（阈值 18~24）只有约 5° 以内的近乎纯水平滑动才能触发——单纯放宽横向判定无效。

## 改动内容
- `main.dart`：鸿蒙下全局覆盖 MediaQuery `gestureSettings`，把竖向 touchSlop 恢复为 Android 水平的 8 逻辑像素（列表滚动手感与 Android 一致）
- `touchSlopH` 默认 24→12：与竖向 8 形成约 34° 的主导方向分界（用户自定义过的设置不受影响）
- 方向判定 `dx > 3·dy` 放宽为 `dx > dy`