### PR TITLE
fix(pip): 支持系统小窗内进入画中画并修复相关播放与布局问题

### DIFF
--- a/lib/pages/live_room/view.dart
+++ b/lib/pages/live_room/view.dart
@@ -67,6 +67,7 @@ class _LiveRoomPageState extends State<LiveRoomPage>
   late final GlobalKey chatKey = GlobalKey();
   late final GlobalKey scKey = GlobalKey();
   late final GlobalKey playerKey = GlobalKey();
+  Worker? _pipModeWorker;
 
   @override
   void initState() {
@@ -79,6 +80,11 @@ class _LiveRoomPageState extends State<LiveRoomPage>
     plPlayerController = _liveRoomController.plPlayerController
       ..addStatusLister(playerListener);
     PlPlayerController.setPlayCallBack(plPlayerController.play);
+    // 画中画状态翻转时强制重建，防止 PiP 结束时无视口变化导致页面滞留在
+    // 画中画布局（参见视频页同名逻辑）。
+    _pipModeWorker = ever(plPlayerController.pipModeRx, (_) {
+      if (mounted) setState(() {});
+    });
   }
 
   @override
@@ -151,6 +157,7 @@ class _LiveRoomPageState extends State<LiveRoomPage>
 
   @override
   void dispose() {
+    _pipModeWorker?.dispose();
     videoPlayerServiceHandler?.onVideoDetailDispose(heroTag);
     WidgetsBinding.instance.removeObserver(this);
     if ((Platform.isAndroid || OS.isHarmony) && !plPlayerController.setSystemBrightness) {

--- a/lib/pages/live_room/widgets/header_control.dart
+++ b/lib/pages/live_room/widgets/header_control.dart
@@ -10,6 +10,7 @@ import 'package:PiliPlus/services/shutdown_timer_service.dart'
 import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:floating/floating.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:get/get.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -166,7 +167,11 @@ class _LiveHeaderControlState extends State<LiveHeaderControl>
                   return;
                 }
                 if (await Floating().isPipAvailable) {
-                  plPlayerController.enterPip();
+                  final status = await plPlayerController.enterPip();
+                  if (OS.isHarmony && status == PiPStatus.unavailable) {
+                    // 系统小窗（自由窗口）内画中画无法启动，插件会拒绝
+                    SmartDialog.showToast('当前处于系统小窗，无法进入画中画');
+                  }
                 }
               },
               icon: const Icon(

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -130,12 +130,23 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
   final videoRelatedKey = GlobalKey();
   final videoIntroKey = GlobalKey();
 
+  Worker? _pipModeWorker;
+
   @override
   void initState() {
     super.initState();
 
     PlPlayerController.setPlayCallBack(playCallBack);
     videoDetailController = Get.put(VideoDetailController(), tag: heroTag);
+    // 画中画状态翻转时强制重建：PiP 结束时若窗口尺寸恰好没变（如画中画
+    // 期间从智慧多窗应用栏以小窗打开 app），没有视口变化触发重建，页面
+    // 会滞留在画中画布局（黑边+播控被状态栏遮挡）。
+    _pipModeWorker = ever(
+      videoDetailController.plPlayerController.pipModeRx,
+      (_) {
+        if (mounted) setState(() {});
+      },
+    );
 
     if (videoDetailController.showReply) {
       _videoReplyController = Get.put(
@@ -327,6 +338,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
 
   @override
   void dispose() {
+    _pipModeWorker?.dispose();
     plPlayerController
       ?..removeStatusLister(playerListener)
       ..removePositionListener(positionListener);

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -2056,7 +2056,12 @@ class HeaderControlState extends State<HeaderControl>
                           await Future.delayed(const Duration(seconds: 3));
                         }
                         if (!context.mounted) return;
-                        plPlayerController.enterPip();
+                        final status = await plPlayerController.enterPip();
+                        if (OS.isHarmony &&
+                            status == PiPStatus.unavailable) {
+                          // 系统小窗（自由窗口）内画中画无法启动，插件会拒绝
+                          SmartDialog.showToast('当前处于系统小窗，无法进入画中画');
+                        }
                       }
                     },
                     icon: const Icon(

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -222,6 +222,11 @@ class PlPlayerController with BlockConfigMixin {
   bool get isPipMode =>
       ((Platform.isAndroid || OS.isHarmony) && Floating().isPipMode) ||
       (PlatformUtils.isDesktop && isDesktopPip);
+
+  /// [isPipMode] 的响应式镜像（仅鸿蒙由 onPipModeChanged 驱动）。页面布局
+  /// 依赖 isPipMode 时应同时监听它触发重建，否则 PiP 结束时若无视口变化
+  /// 页面会滞留在画中画布局。
+  final RxBool pipModeRx = false.obs;
   late bool isDesktopPip = false;
   late Rect _lastWindowBounds;
 
@@ -304,16 +309,17 @@ class PlPlayerController with BlockConfigMixin {
         previousRoute.startsWith('/liveRoom');
   }
 
-  void enterPip({bool isAuto = false}) {
+  Future<PiPStatus> enterPip({bool isAuto = false}) {
     if (videoPlayerController != null) {
       controls = false;
       final state = videoPlayerController!.state;
-      PageUtils.enterPip(
+      return PageUtils.enterPip(
         isAuto: isAuto,
         width: state.width == 0 ? width : state.width,
         height: state.height == 0 ? height : state.height,
       );
     }
+    return Future.value(PiPStatus.unavailable);
   }
 
   void _disableAutoEnterPipIfNeeded() {
@@ -949,6 +955,11 @@ class PlPlayerController with BlockConfigMixin {
     if (OS.isHarmony) {
       _startStallWatchdog();
       Floating().onPipAction = _onPipAction;
+      // isPipMode 是普通 bool，build 读它不产生依赖；PiP 结束时若窗口尺寸
+      // 恰好没变（如画中画期间从应用栏以小窗打开 app），没有任何重建时机，
+      // 页面会冻结在画中画布局。用回调驱动 pipModeRx，页面据此重建。
+      Floating().onPipModeChanged = (v) => pipModeRx.value = v;
+      pipModeRx.value = Floating().isPipMode;
     }
     final stream = player.stream;
     _subscriptions = [
@@ -974,6 +985,18 @@ class PlPlayerController with BlockConfigMixin {
             _disableAutoEnterPip();
           }
           playerStatus.value = PlayerStatus.paused;
+          // 鸿蒙：进入画中画的退后台过程中，系统会直接把 mpv 置为暂停
+          //（应用层无任何 pause 调用，插桩证实；auto-start 武装与否均如此）。
+          // 画中画窗口可见即应继续播放，且普通 play() 即可恢复（等效于
+          // 用户按面板播放键），这里自动补上。_pauseRequestedByApp 排除
+          // 用户/业务暂停，频率闸防止与系统拉锯。
+          if (OS.isHarmony &&
+              !_pauseRequestedByApp &&
+              isPipMode &&
+              !(videoPlayerController?.state.completed ?? false) &&
+              _pipAutoResumeAllowed()) {
+            play();
+          }
         }
         if (OS.isHarmony) {
           // 同步鸿蒙小窗控制面板的播放/暂停图标
@@ -1254,6 +1277,7 @@ class PlPlayerController with BlockConfigMixin {
   /// 播放视频
   Future<void> play({bool repeat = false, bool hideControls = true}) async {
     if (_playerCount == 0) return;
+    _pauseRequestedByApp = false;
     // 播放时自动隐藏控制条
     controls = !hideControls;
     // repeat为true，将从头播放
@@ -1286,7 +1310,42 @@ class PlPlayerController with BlockConfigMixin {
   }
 
   /// 暂停播放
+  /// 应用层是否主动发起了当前这次暂停。用于区分"系统在进入画中画的退后台
+  /// 过程中直接把 mpv 置为暂停"（Dart 层无任何 pause 调用，需要自动恢复）
+  /// 与用户/业务发起的正常暂停。
+  bool _pauseRequestedByApp = false;
+  int _pipAutoResumeCount = 0;
+  DateTime? _pipAutoResumeWindowStart;
+
+  /// 生命周期回调的补偿入口：处于画中画且播放被系统静默暂停（而非应用
+  /// 主动暂停）时自动续播。覆盖"系统暂停发生在 isPipMode 置位之前"的
+  /// 时序——彼时 stream.playing 监听里的自动续播不满足条件，只能靠随后
+  /// 到达的生命周期事件（floating 插件会在 PiP 启动后补发 inactive）触发。
+  void autoResumeInPipIfNeeded() {
+    if (OS.isHarmony &&
+        !_pauseRequestedByApp &&
+        isPipMode &&
+        !playerStatus.isPlaying &&
+        !(videoPlayerController?.state.completed ?? false) &&
+        _pipAutoResumeAllowed()) {
+      play();
+    }
+  }
+
+  /// 限制画中画内自动续播的频率，防止与系统的强制暂停陷入拉锯。
+  bool _pipAutoResumeAllowed() {
+    final now = DateTime.now();
+    if (_pipAutoResumeWindowStart == null ||
+        now.difference(_pipAutoResumeWindowStart!) >
+            const Duration(seconds: 10)) {
+      _pipAutoResumeWindowStart = now;
+      _pipAutoResumeCount = 0;
+    }
+    return ++_pipAutoResumeCount <= 3;
+  }
+
   Future<void> pause({bool notify = true, bool isInterrupt = false}) async {
+    _pauseRequestedByApp = true;
     await _videoPlayerController?.pause();
     playerStatus.value = PlayerStatus.paused;
 

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -321,11 +321,19 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     late final player = plPlayerController.videoPlayerController;
     if(player == null) return;
+    if (state != AppLifecycleState.paused &&
+        state != AppLifecycleState.detached) {
+      plPlayerController.autoResumeInPipIfNeeded();
+    }
     if (!plPlayerController.continuePlayInBackground.value) {
       if (const [
         AppLifecycleState.paused,
         AppLifecycleState.detached,
       ].contains(state)) {
+        // 画中画中收到的 paused 来自进入 PiP 时的退后台（鸿蒙），视频仍然
+        // 可见，不算后台，不应暂停。PiP 关闭且留在后台时，插件先推
+        // isPipMode=false 再补发 paused，此处仍会正常暂停。
+        if (plPlayerController.isPipMode) return;
         if (player.state.playing) {
           _pauseDueToPauseUponEnteringBackgroundMode = true;
           player.pause();

--- a/lib/utils/page_utils.dart
+++ b/lib/utils/page_utils.dart
@@ -187,7 +187,11 @@ abstract final class PageUtils {
     );
   }
 
-  static void enterPip({int? width, int? height, bool isAuto = false}) {
+  static Future<PiPStatus> enterPip({
+    int? width,
+    int? height,
+    bool isAuto = false,
+  }) {
     if (width != null && height != null) {
       Rational aspectRatio = Rational(width, height);
       aspectRatio = aspectRatio.fitsInAndroidRequirements
@@ -195,13 +199,15 @@ abstract final class PageUtils {
           : height > width
           ? const Rational.vertical()
           : const Rational.landscape();
-      Floating().enable(
+      return Floating().enable(
         isAuto
             ? AutoEnable(aspectRatio: aspectRatio)
             : EnableManual(aspectRatio: aspectRatio),
       );
     } else {
-      Floating().enable(isAuto ? const AutoEnable() : const EnableManual());
+      return Floating().enable(
+        isAuto ? const AutoEnable() : const EnableManual(),
+      );
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -637,8 +637,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "8aef0f9762fbe9077ca9573e531a11afaad86d13"
-      resolved-ref: "8aef0f9762fbe9077ca9573e531a11afaad86d13"
+      ref: cd53ec36b91e0d346678ce9c1942a2b6ab4a11ab
+      resolved-ref: cd53ec36b91e0d346678ce9c1942a2b6ab4a11ab
       url: "https://github.com/qinshah/floating.git"
     source: git
     version: "3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -178,7 +178,7 @@ dependencies:
   floating:
     git:
       url: https://github.com/qinshah/floating.git
-      ref: 8aef0f9762fbe9077ca9573e531a11afaad86d13
+      ref: cd53ec36b91e0d346678ce9c1942a2b6ab4a11ab
       
     # html解析
   html: ^0.15.4


### PR DESCRIPTION
## 问题
在系统小窗（屏幕底部上滑挂起的自由窗口）内点击画中画按钮，画中画不会启动，且回到应用后页面永久停留在画中画布局（视频居中 + 上下大面积黑边，播控组件被状态栏遮挡无法点击），切换视频也不恢复。此外还存在两个关联问题：
- 未开启后台播放时，进入画中画的退后台过程中系统会直接把 mpv 置为暂停，画中画以暂停态起播且无人恢复；
- 画中画期间从智慧多窗应用栏以小窗打开应用，页面滞留在画中画布局（切全屏可自愈、新视频正常，但当前页面卡死）。

## 前置依赖
配合 qinshah/floating 已合并的小窗画中画修复（系统小窗内"退后台 + 显式 `startPiP()`"直启、手动 enable 不再急切设置 `isPipMode`、新增 `onPipModeChanged` 回调、`stopPiP` 被拒自愈）。本 PR 已包含 pubspec 中 floating ref 的升级。

## 修改
- `enterPip` 链路（`PageUtils` / `PlPlayerController`）返回 `Future<PiPStatus>`；视频页与直播页的画中画按钮在插件被窗管拒绝（兜底路径）时弹 toast 提示
- 生命周期处理：画中画中收到 paused（进入 PiP 时退后台所致，视频仍可见）不再暂停播放器；PiP 关闭且留在后台时插件先推 `isPipMode=false` 再补发paused，"无后台播放则后台静音"的语义不受影响
- 画中画内自动续播：新增 `_pauseRequestedByApp` 区分应用主动暂停与系统静默暂停，检测到后者时自动 `play()` 恢复（10 秒窗口内最多 3 次，防止与系统拉锯）；用户在画中画面板手动暂停不受影响
- 新增 `pipModeRx`（由 floating 新回调 `onPipModeChanged` 驱动），视频页与直播页监听其翻转强制重建，修复PiP 结束时无视口变化则页面滞留画中画布局的问题