### PR TITLE
feat(ohos): 画中画面板支持快进/快退按钮

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1154,14 +1154,20 @@ class PlPlayerController with BlockConfigMixin {
 
   /// 鸿蒙小窗控制面板按钮回调（floating 插件转发 controlPanelActionEvent）
   void _onPipAction(String event, int? status) {
-    if (event == 'playbackStateChanged') {
-      // status: 1=请求播放，0=请求暂停；缺省时按当前状态取反
-      final wantPlay = status == null ? !playerStatus.isPlaying : status == 1;
-      if (wantPlay) {
-        play();
-      } else {
-        pause();
-      }
+    switch (event) {
+      case 'playbackStateChanged':
+        // status: 1=请求播放，0=请求暂停；缺省时按当前状态取反
+        final wantPlay =
+            status == null ? !playerStatus.isPlaying : status == 1;
+        if (wantPlay) {
+          play();
+        } else {
+          pause();
+        }
+      case 'fastForward':
+        onForward(fastForBackwardDuration);
+      case 'fastBackward':
+        onBackward(fastForBackwardDuration);
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -637,8 +637,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: cd53ec36b91e0d346678ce9c1942a2b6ab4a11ab
-      resolved-ref: cd53ec36b91e0d346678ce9c1942a2b6ab4a11ab
+      ref: "3eefccb759c4ea8114e722f1511fe1dbce70dc9f"
+      resolved-ref: "3eefccb759c4ea8114e722f1511fe1dbce70dc9f"
       url: "https://github.com/qinshah/floating.git"
     source: git
     version: "3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -178,7 +178,7 @@ dependencies:
   floating:
     git:
       url: https://github.com/qinshah/floating.git
-      ref: cd53ec36b91e0d346678ce9c1942a2b6ab4a11ab
+      ref: 3eefccb759c4ea8114e722f1511fe1dbce70dc9f
       
     # html解析
   html: ^0.15.4


### PR DESCRIPTION
## 功能
鸿蒙画中画的系统控制面板此前只有播放/暂停按钮。配合 floating 插件的配套 PR [3#](https://github.com/qinshah/floating/pull/3)（VIDEO_PLAY) 模板启用 FAST_FORWARD_BACKWARD 控件组），面板在播放/暂停两侧显示快退/快进按钮，点击后按"双击快进/快退时长"设置
（默认 10s，可选 5/10/15s）seek，对齐安卓版画中画的快进/快退能力。

## 实现
- `pl_player/controller.dart` 的 `_onPipAction`（floating 插件转发的小窗面板按钮回调）新增 `fastForward` / `fastBackward` 分支，复用既有的 `onForward` / `onBackward`，时长取 `fastForBackwardDuration`（即"双击快进/快退时长"设置）。行为与应用内双击快进/快退完全一致：seek 后续播、位置 clamp 到 [0, 时长]。
- 鸿蒙侧按钮排布与渲染由系统负责；插件侧改动见 floating 的配套 PR [3#](https://github.com/qinshah/floating/pull/3)。