### PR TITLE
refactor(ohos): 移除接续功能不再需要的 DISTRIBUTED_DATASYNC 权限

### DIFF
--- a/ohos/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/ohos/entry/src/main/ets/entryability/EntryAbility.ets
@@ -1,4 +1,4 @@
-import { abilityAccessCtrl, common } from "@kit.AbilityKit";
+import { common } from "@kit.AbilityKit";
 import { BusinessError } from "@kit.BasicServicesKit";
 import { fileIo, fileUri, picker } from "@kit.CoreFileKit";
 import AbilityConstant from "@ohos.app.ability.AbilityConstant";
@@ -82,14 +82,6 @@ export default class EntryAbility extends FlutterAbility {
 
   async onWindowStageCreate(windowStage: window.WindowStage): Promise<void> {
     super.onWindowStageCreate(windowStage);
-    // 跨设备接续要求两端均授予多设备协同权限（user_grant，需弹窗授权；
-    // 已授权或已被拒绝时系统不再弹窗）
-    abilityAccessCtrl
-      .createAtManager()
-      .requestPermissionsFromUser(this.context, ["ohos.permission.DISTRIBUTED_DATASYNC"])
-      .catch((err: BusinessError) => {
-        console.error(`request DISTRIBUTED_DATASYNC failed: ${err.code} ${err.message}`);
-      });
     let w = windowStage.getMainWindowSync();
     w.on("windowStatusChange", (type) => {
       if (type == window.WindowStatusType.FLOATING && !this.wasFloatingWindow) {

--- a/ohos/entry/src/main/module.json5
+++ b/ohos/entry/src/main/module.json5
@@ -73,14 +73,6 @@
           when: "inuse",
         },
       },
-      {
-        name: "ohos.permission.DISTRIBUTED_DATASYNC",
-        reason: "$string:perm_distributed_datasync_reason",
-        usedScene: {
-          abilities: ["EntryAbility"],
-          when: "inuse",
-        },
-      },
     ],
   },
 }

--- a/ohos/entry/src/main/resources/base/element/string.json
+++ b/ohos/entry/src/main/resources/base/element/string.json
@@ -37,10 +37,6 @@
       "value": "用于读取剪贴板内容。"
     },
     {
-      "name": "perm_distributed_datasync_reason",
-      "value": "用于在多设备间接续视频播放进度。"
-    },
-    {
       "name": "no_matter",
       "value": "no matter"
     }

--- a/ohos/entry/src/main/resources/en_US/element/string.json
+++ b/ohos/entry/src/main/resources/en_US/element/string.json
@@ -17,10 +17,6 @@
       "value": "Allow saving images/videos to gallery."
     },
     {
-      "name": "perm_distributed_datasync_reason",
-      "value": "Used to continue video playback across your devices."
-    },
-    {
       "name": "no_matter",
       "value": "no matter"
     }


### PR DESCRIPTION
自 API12 起，跨设备接续无需申请 `ohos.permission.DISTRIBUTED_DATASYNC`，本项目 compatibleSdkVersion 为 5.0.3(15)，可直接移除该权限声明与启动时的授权弹窗，减少一次不必要的权限打扰。
- EntryAbility.ets: 删除 `onWindowStageCreate` 中的 `requestPermissionsFromUser` 调用
- module.json5: 删除该权限声明
- string.json(base/zh_CN/en_US): 删除对应的权限用途文案