### PR TITLE
refactor(ohos): 补删 zh_CN 中遗留的 DISTRIBUTED_DATASYNC 权限文案

### DIFF
--- a/ohos/entry/src/main/resources/zh_CN/element/string.json
+++ b/ohos/entry/src/main/resources/zh_CN/element/string.json
@@ -17,10 +17,6 @@
       "value": "用于保存图片/视频到相册。"
     },
     {
-      "name": "perm_distributed_datasync_reason",
-      "value": "用于在多设备间接续视频播放进度。"
-    },
-    {
       "name": "no_matter",
       "value": "这种权限给就完了你别管"
     }


### PR DESCRIPTION
上一次移除该权限时漏改了 zh_CN 的 string.json，导致 perm_distributed_datasync_reason 文案在权限声明已删除后仍然残留。