### PR TITLE
feat(audio_service): 实现鸿蒙播控中心上一集/下一集

### DIFF
--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -132,10 +132,14 @@ class AudioController extends GetxController
         _queryPlayUrl();
       }
     });
-    videoPlayerServiceHandler
-      ?..onPlay = onPlay
-      ..onPause = onPause
-      ..onSeek = onSeek;
+    final handler = videoPlayerServiceHandler;
+    if (handler != null) {
+      handler.onPlay = onPlay;
+      handler.onPause = onPause;
+      handler.onSeek = onSeek;
+      handler.onSkipToPrevious = () async => playPrev();
+      handler.onSkipToNext = () async => playNext();
+    }
 
     animController = AnimationController(
       vsync: this,
@@ -780,11 +784,15 @@ class AudioController extends GetxController
       ..onPause = null
       ..isPlaying = null
       ..reset();
-    videoPlayerServiceHandler
-      ?..onPlay = null
-      ..onPause = null
-      ..onSeek = null
-      ..onVideoDetailDispose(hashCode.toString());
+    videoPlayerServiceHandler?.onVideoDetailDispose(hashCode.toString());
+    final handler = videoPlayerServiceHandler;
+    if (handler != null) {
+      handler.onPlay = null;
+      handler.onPause = null;
+      handler.onSeek = null;
+      handler.onSkipToPrevious = null;
+      handler.onSkipToNext = null;
+    }
     _subscriptions?.forEach((e) => e.cancel());
     _subscriptions?.clear();
     _subscriptions = null;

--- a/lib/pages/video/introduction/pgc/controller.dart
+++ b/lib/pages/video/introduction/pgc/controller.dart
@@ -63,6 +63,10 @@ class PgcIntroController extends CommonIntroController {
 
     super.onInit();
 
+    // 注册播控中心上一集/下一集回调
+    videoPlayerServiceHandler?.onSkipToPrevious = () async => prevPlay();
+    videoPlayerServiceHandler?.onSkipToNext = () async => nextPlay();
+
     if (isPgc) {
       if (isLogin) {
         queryIsFollowed();

--- a/lib/pages/video/introduction/ugc/controller.dart
+++ b/lib/pages/video/introduction/ugc/controller.dart
@@ -82,6 +82,10 @@ class UgcIntroController extends CommonIntroController with ReloadMixin {
     }
 
     videoDetail.value.title = Get.arguments['title'] ?? '';
+
+    // 注册播控中心上一集/下一集回调
+    videoPlayerServiceHandler?.onSkipToPrevious = () async => prevPlay();
+    videoPlayerServiceHandler?.onSkipToNext = () async => nextPlay();
   }
 
   // 获取视频简介&分p

--- a/lib/services/audio_handler.dart
+++ b/lib/services/audio_handler.dart
@@ -46,6 +46,8 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
   Future<void>? Function()? onPlay;
   Future<void>? Function()? onPause;
   Future<void>? Function(Duration position)? onSeek;
+  Future<bool>? Function()? onSkipToNext;
+  Future<bool>? Function()? onSkipToPrevious;
 
   @override
   Future<void> play() {
@@ -71,6 +73,16 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
     return (onSeek?.call(position) ??
         PlPlayerController.seekToIfExists(position, isSeek: false));
     // await player.seekTo(position);
+  }
+
+  @override
+  Future<void> skipToNext() async {
+    await onSkipToNext?.call();
+  }
+
+  @override
+  Future<void> skipToPrevious() async {
+    await onSkipToPrevious?.call();
   }
 
   void setMediaItem(MediaItem newMediaItem) {
@@ -115,7 +127,15 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
             MediaControl.rewind.copyWith(
               androidIcon: 'drawable/ic_baseline_replay_10_24',
             ),
+          if (!isLive)
+            MediaControl.skipToPrevious.copyWith(
+              androidIcon: 'drawable/ic_skip_previous',
+            ),
           if (playing) MediaControl.pause else MediaControl.play,
+          if (!isLive)
+            MediaControl.skipToNext.copyWith(
+              androidIcon: 'drawable/ic_skip_next',
+            ),
           if (!isLive)
             MediaControl.fastForward.copyWith(
               androidIcon: 'drawable/ic_baseline_forward_10_24',
@@ -124,6 +144,8 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
         playing: playing,
         systemActions: const {
           MediaAction.seek,
+          MediaAction.skipToNext,
+          MediaAction.skipToPrevious,
         },
       ),
     );


### PR DESCRIPTION
原先 VideoPlayerServiceHandler 未重写 skipToNext/skipToPrevious， 播控中心上一集/下一集按钮无响应。

通过在 VideoPlayerServiceHandler 中新增 onSkipToNext/onSkipToPrevious 回调字段，各页面控制器在 onInit 中注册对应逻辑：
- UgcIntroController: prevPlay/nextPlay（分P/合集切换）
- PgcIntroController: prevPlay/nextPlay（番剧切换）
- AudioController: playPrev/playNext（音频列表切换）

onClose 中清理回调。