### PR TITLE
注册 bilibili URI Scheme 支持从浏览器唤起 PiliPlus

### DIFF
--- a/ohos/entry/src/main/module.json5
+++ b/ohos/entry/src/main/module.json5
@@ -27,6 +27,45 @@
             entities: ["entity.system.home"],
             actions: ["action.system.home"],
           },
+          {
+            actions: ["ohos.want.action.viewData"],
+            entities: ["entity.system.default"],
+            uris: [
+              {
+                scheme: "bilibili",
+              },
+            ],
+          },
+          {
+            actions: ["ohos.want.action.viewData"],
+            entities: ["entity.system.default"],
+            uris: [
+              {
+                scheme: "https",
+                host: "bilibili.com",
+              },
+              {
+                scheme: "https",
+                host: "www.bilibili.com",
+              },
+              {
+                scheme: "https",
+                host: "b23.tv",
+              },
+              {
+                scheme: "http",
+                host: "bilibili.com",
+              },
+              {
+                scheme: "http",
+                host: "www.bilibili.com",
+              },
+              {
+                scheme: "http",
+                host: "b23.tv",
+              },
+            ],
+          },
         ],
       },
     ],


### PR DESCRIPTION
在 ohos/entry/src/main/module.json5 中为 EntryAbility 添加两个新 skill：

1. bilibili:// 自定义 scheme — 处理 bilibili://video/BVxxx 等链接
2. HTTP/HTTPS 域名 处理 https://www.bilibili.com、b23.tv等url

相关路由处理上游已经实现