### PR TITLE
fix(ui): 修复视频详情页状态栏隐藏逻辑

### DIFF
--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -530,7 +530,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
 
   Widget get childWhenDisabled {
     if (PlatformUtils.isMobile && mounted && isShowing && !isFullScreen) {
-      if (videoDetailController.horizontalScreen || videoDetailController.removeSafeArea) {
+      if (videoDetailController.removeSafeArea) {
         hideSystemBar();
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
 # update when release
-version: 2.1.0+5583
+version: 2.1.0+5584
 
 environment:
   sdk: ">=3.11.1"


### PR DESCRIPTION
调整状态栏隐藏的触发条件，移除对横屏状态的依赖，仅在
`removeSafeArea` 为 true 时执行 `hideSystemBar`