### PR TITLE
fix(ohos): 修复沉浸光感顶栏下的下拉刷新遮挡与平板横屏分类栏消失

### DIFF
--- a/lib/common/widgets/native_top_spacer.dart
+++ b/lib/common/widgets/native_top_spacer.dart
@@ -1,8 +1,10 @@
+import 'dart:math';
+
+import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
 import 'package:PiliPlus/pages/home/controller.dart';
 import 'package:PiliPlus/pages/main/controller.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:os_type/os_type.dart';
 
 /// 原生顶栏启用时，首页各 Tab 列表顶部注入的可滚动留白。
 ///
@@ -27,25 +29,58 @@ class NativeTopSpacer extends StatelessWidget {
   static const double singleExpandedHeight = 55;
   static const double singleCollapsedHeight = 0;
 
+  /// ArkTS 顶栏自身的高度，须与 Index.ets 的 TOP_BAR_EXPANDED_HEIGHT /
+  /// TOP_BAR_COLLAPSED_HEIGHT 保持一致（顶栏从屏幕顶端起算，含状态栏）。
+  static const double barExpandedHeight = 144;
+  static const double barCollapsedHeight = 80;
+
+  /// 原生顶栏当前是否真正生效（响应式读取，供 Obx 依赖）。
+  /// 仅鸿蒙的 _initHdsBar 会置位 nativeTopBarActive，无需再判平台；
+  /// 横屏/侧栏布局下 ArkTS 顶栏已被隐藏，此处同样返回 false。
+  static bool get _active =>
+      Get.find<MainController>().nativeTopBarActive.value;
+
+  static HomeController? get _homeController {
+    try {
+      return Get.find<HomeController>();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// 顶栏是否处于收起态（收起时 ArkTS 顶栏只剩小搜索按钮）
+  static bool get _collapsed => _homeController?.topBarCollapsed.value ?? false;
+
   /// 首页其他非滚动容器（如分区左侧标签栏）的静态留白高度。
   /// 禁用原生顶栏时返回 0。
   /// 按分类标签数量区分：
   /// - 仅一个分类：展开 55vp / 收起 0vp
   /// - 多个分类：展开 85vp / 收起 30vp
   static double staticHeight(BuildContext context) {
-    final useNativeTopBar =
-        OS.isHarmony && Get.find<MainController>().useNativeTopBar.value;
-    if (!useNativeTopBar) return 0;
-    HomeController? homeController;
-    try {
-      homeController = Get.find<HomeController>();
-    } catch (_) {}
-    final collapsed = homeController?.topBarCollapsed.value ?? false;
-    final single = (homeController?.tabs.length ?? 0) <= 1;
+    if (!_active) return 0;
+    final collapsed = _collapsed;
+    final single = (_homeController?.tabs.length ?? 0) <= 1;
     if (single) {
       return collapsed ? singleCollapsedHeight : singleExpandedHeight;
     }
     return collapsed ? collapsedHeight : expandedHeight;
+  }
+
+  /// 下拉刷新指示器的顶部偏移（RefreshIndicator.edgeOffset）。
+  ///
+  /// 列表本身是全屏沉浸的，转圈默认贴着列表顶边（= 状态栏下沿）出现，
+  /// 会被 ArkTS 顶栏整个盖住。此处把它下移到顶栏底边，转圈仍按
+  /// displacement 落在「可视顶边下方」，与非沉浸页面观感一致。
+  ///
+  /// 主内容区顶部已由 Scaffold 的 AppBar(toolbarHeight: 0) 吃掉状态栏高度，
+  /// 故只需避让顶栏在状态栏以下的部分。Scaffold body 内 MediaQuery 的
+  /// padding/viewPadding 顶部均已被移除，这里直接从 View 读物理值换算。
+  static double refreshEdgeOffset(BuildContext context) {
+    if (!_active) return 0;
+    final barHeight = _collapsed ? barCollapsedHeight : barExpandedHeight;
+    final view = View.of(context);
+    final statusBarHeight = view.viewPadding.top / view.devicePixelRatio;
+    return max(0.0, barHeight - statusBarHeight);
   }
 
   @override
@@ -61,6 +96,35 @@ class NativeTopSpacer extends StatelessWidget {
           curve: Curves.linear,
           height: staticHeight(context),
         ),
+      ),
+    );
+  }
+}
+
+/// 首页各 Tab 列表的下拉刷新包装：原生顶栏启用时把转圈下移到顶栏下方，
+/// 避免刷新指示器被 ArkTS 顶栏遮挡；未启用（含横屏/侧栏布局）时
+/// edgeOffset 为 0，与普通 refreshIndicator 完全一致。
+///
+/// 用 Obx 包裹以跟随 nativeTopBarActive 异步就绪 / topBarCollapsed 变化；
+/// child 由外层 build 构造并被闭包捕获，Obx 重建时是同一个 widget 实例，
+/// 列表子树不会跟着重建。
+class NativeTopRefreshIndicator extends StatelessWidget {
+  const NativeTopRefreshIndicator({
+    super.key,
+    required this.onRefresh,
+    required this.child,
+  });
+
+  final RefreshCallback onRefresh;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(
+      () => refreshIndicator(
+        edgeOffset: NativeTopSpacer.refreshEdgeOffset(context),
+        onRefresh: onRefresh,
+        child: child,
       ),
     );
   }

--- a/lib/pages/home/view.dart
+++ b/lib/pages/home/view.dart
@@ -12,7 +12,6 @@ import 'package:PiliPlus/utils/feed_back.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
-import 'package:os_type/os_type.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -36,11 +35,11 @@ class _HomePageState extends CommonPageState<HomePage>
   @override
   void initState() {
     super.initState();
-    // 鸿蒙顶栏异步就绪后重建，隐藏 Flutter 顶栏/分类栏。
+    // 鸿蒙顶栏异步就绪 / 横竖屏切换后重建，显示或隐藏 Flutter 顶栏、分类栏。
     // 状态栏安全区移除由窗口沉浸实现（EntryAbility 设置
     // setWindowLayoutFullScreen(true) + 状态栏背景透明），保留系统状态栏
-    // 图标；此处仅负责按 useNativeTopBar 重建 UI 布局，不操作系统状态栏。
-    _nativeTopBarWorker = ever(_mainController.useNativeTopBar, (_) {
+    // 图标；此处仅负责按顶栏是否生效重建 UI 布局，不操作系统状态栏。
+    _nativeTopBarWorker = ever(_mainController.nativeTopBarActive, (_) {
       if (mounted) setState(() {});
     });
   }
@@ -55,9 +54,10 @@ class _HomePageState extends CommonPageState<HomePage>
   Widget build(BuildContext context) {
     super.build(context);
     final theme = Theme.of(context);
-    // 鸿蒙原生顶栏启用时隐藏 Flutter 顶部控件
-    final useNativeTopBar =
-        OS.isHarmony && _mainController.useNativeTopBar.value;
+    // 鸿蒙原生顶栏生效时隐藏 Flutter 顶部控件。
+    // 横屏/侧栏布局下 ArkTS 顶栏是隐藏的，此处必须恢复 Flutter 分类栏，
+    // 否则分类栏消失且顶部留白（NativeTopSpacer）空出一大片。
+    final useNativeTopBar = _mainController.nativeTopBarActive.value;
     Widget tabBar;
     if (_homeController.tabs.length > 1) {
       tabBar = Padding(

--- a/lib/pages/hot/view.dart
+++ b/lib/pages/hot/view.dart
@@ -1,4 +1,3 @@
-import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/native_top_spacer.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
@@ -60,7 +59,7 @@ class _HotPageState extends State<HotPage>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return refreshIndicator(
+    return NativeTopRefreshIndicator(
       onRefresh: controller.onRefresh,
       child: CustomScrollView(
         physics: const AlwaysScrollableScrollPhysics(),

--- a/lib/pages/live/view.dart
+++ b/lib/pages/live/view.dart
@@ -3,7 +3,6 @@ import 'package:PiliPlus/common/widgets/native_top_spacer.dart';
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/common/widgets/button/icon_button.dart';
 import 'package:PiliPlus/common/widgets/button/more_btn.dart';
-import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
 import 'package:PiliPlus/common/widgets/pair.dart';
@@ -55,7 +54,7 @@ class _LivePageState extends State<LivePage>
       clipBehavior: Clip.hardEdge,
       margin: const EdgeInsets.symmetric(horizontal: Style.safeSpace),
       decoration: const BoxDecoration(borderRadius: Style.mdRadius),
-      child: refreshIndicator(
+      child: NativeTopRefreshIndicator(
         onRefresh: controller.onRefresh,
         child: CustomScrollView(
           controller: controller.scrollController,

--- a/lib/pages/main/controller.dart
+++ b/lib/pages/main/controller.dart
@@ -36,7 +36,14 @@ class MainController extends GetxController
   RxBool? showBottomBar;
   late final bool hideBottomBar;
   late final barHideType = Pref.barHideType;
-  bool useBottomNav = false;
+  bool _useBottomNav = false;
+  bool get useBottomNav => _useBottomNav;
+  set useBottomNav(bool value) {
+    if (_useBottomNav == value) return;
+    _useBottomNav = value;
+    _syncNativeTopBarActive();
+  }
+
   late dynamic controller;
   final RxInt selectedIndex = 0.obs;
   /// ArkTS 发起的页签切换，跳过回传 ArkTS 以避免循环
@@ -66,6 +73,17 @@ class MainController extends GetxController
 
   /// 鸿蒙原生顶部沉浸栏（与 useNativeTabs 同开关，API >= 23 时启用）
   final RxBool useNativeTopBar = false.obs;
+
+  /// 原生顶栏在当前布局下是否真正生效：仅竖屏底栏布局由 ArkTS 渲染顶栏。
+  /// 横屏 / 侧栏布局（useBottomNav == false）下 ArkTS 顶栏已被
+  /// ShellBarsObserver 隐藏，此时 Flutter 必须恢复自绘分类栏并取消顶部留白，
+  /// 否则分类栏消失、顶部还留下一大片空白。
+  final RxBool nativeTopBarActive = false.obs;
+
+  /// useNativeTopBar / useBottomNav 任一变化后重算顶栏是否生效
+  void _syncNativeTopBarActive() {
+    nativeTopBarActive.value = useNativeTopBar.value && _useBottomNav;
+  }
 
   final floatingNavBar = Pref.floatingNavBar;
   final useSideBar = Pref.useSideBar;
@@ -163,6 +181,7 @@ class MainController extends GetxController
         apiVersion != null && apiVersion >= 23 && enableHdsTopBar;
     useNativeTabs.value = useNative;
     useNativeTopBar.value = useNativeTop;
+    _syncNativeTopBarActive();
     HarmonyChannel.setShellBars(useNativeTabs: useNative);
     HarmonyChannel.setShellTopBar(useNativeTopBar: useNativeTop);
     // 首页分类标签与顶栏设置同步到原生

--- a/lib/pages/main/view.dart
+++ b/lib/pages/main/view.dart
@@ -79,6 +79,11 @@ class _MainAppState extends PopScopeState<MainApp>
     // 顶栏的分类高亮、图标颜色均读取 tabSelectedColor。
     _nativeTopBarWorker = ever(_mainController.useNativeTopBar, (useNativeTopBar) {
       if (!mounted || !useNativeTopBar) return;
+      // 同样补发首帧时因 useNativeTopBar 未就绪而跳过的顶栏显隐同步：
+      // 横屏（侧栏布局）或已有子页面覆盖主页时，原生顶栏不应显示
+      MyApp.shellBarsObserver.onOrientationChanged(
+        _mainController.useBottomNav,
+      );
       _syncPrimaryColor();
     });
     if (PlatformUtils.isDesktop) {
@@ -112,9 +117,12 @@ class _MainAppState extends PopScopeState<MainApp>
     if (!_mainController.useSideBar) {
       _mainController.useBottomNav = MediaQuery.sizeOf(context).isPortrait;
     }
-    // 横竖屏切换时同步原生 HDS 沉浸底栏显隐
-    // 由 ShellBarsObserver 统一管理，避免与路由观察者冲突
-    if (_mainController.useNativeTabs.value) {
+    // 横竖屏切换时同步原生 HDS 沉浸底栏/顶栏显隐
+    // 由 ShellBarsObserver 统一管理，避免与路由观察者冲突。
+    // 顶栏与底栏是两个独立开关，只启用其一时也要通知，否则横屏下
+    // ArkTS 顶栏不会隐藏。
+    if (_mainController.useNativeTabs.value ||
+        _mainController.useNativeTopBar.value) {
       MyApp.shellBarsObserver.onOrientationChanged(
         _mainController.useBottomNav,
       );

--- a/lib/pages/pgc/view.dart
+++ b/lib/pages/pgc/view.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/common/widgets/button/more_btn.dart';
 import 'package:PiliPlus/common/widgets/native_top_spacer.dart';
-import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/loading_widget.dart';
 import 'package:PiliPlus/common/widgets/scroll_physics.dart';
@@ -56,7 +55,7 @@ class _PgcPageState extends State<PgcPage> with AutomaticKeepAliveClientMixin {
   Widget build(BuildContext context) {
     super.build(context);
     final ThemeData theme = Theme.of(context);
-    return refreshIndicator(
+    return NativeTopRefreshIndicator(
       onRefresh: controller.onRefresh,
       child: CustomScrollView(
         controller: controller.scrollController,

--- a/lib/pages/rank/view.dart
+++ b/lib/pages/rank/view.dart
@@ -1,12 +1,10 @@
 import 'package:PiliPlus/common/widgets/flutter/vertical_tabs.dart';
 import 'package:PiliPlus/common/widgets/native_top_spacer.dart';
 import 'package:PiliPlus/models/common/rank_type.dart';
-import 'package:PiliPlus/pages/main/controller.dart';
 import 'package:PiliPlus/pages/rank/controller.dart';
 import 'package:PiliPlus/pages/rank/zone/view.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:os_type/os_type.dart';
 
 class RankPage extends StatefulWidget {
   const RankPage({super.key});
@@ -51,21 +49,20 @@ class _RankPageState extends State<RankPage>
   }
 
   Widget _buildTab(ThemeData theme) {
-    // 顶部留白需 Obx 包裹：useNativeTopBar 异步就绪 / topBarCollapsed 收起
-    // 变化后自动重建。高度直接复用 NativeTopSpacer.staticHeight，与右侧
-    // ZonePage 列表顶部的 Sliver 留白语义对齐——两者都按「首页分类数 + 
-    // 顶栏收起状态」计算，避免硬编码 magic number 导致左右不对称。
-    return Obx(() {
-      final useNativeTopBar =
-          OS.isHarmony && Get.find<MainController>().useNativeTopBar.value;
-      return VerticalTabBar(
+    // 顶部留白需 Obx 包裹：顶栏是否生效（异步就绪 / 横竖屏切换）、
+    // topBarCollapsed 收起变化后自动重建。高度直接复用
+    // NativeTopSpacer.staticHeight（未启用时返回 0），与右侧 ZonePage 列表
+    // 顶部的 Sliver 留白语义对齐——两者都按「首页分类数 + 顶栏收起状态」
+    // 计算，避免硬编码 magic number 导致左右不对称。
+    return Obx(
+      () => VerticalTabBar(
         dividerWidth: 0,
         isScrollable: true,
         indicatorWeight: 3,
         indicatorSize: .tab,
         controller: _rankController.tabController,
         padding: .only(
-          top: useNativeTopBar ? NativeTopSpacer.staticHeight(context) : 0,
+          top: NativeTopSpacer.staticHeight(context),
           bottom: MediaQuery.paddingOf(context).bottom + 105,
         ),
         tabs: RankType.values.map((e) => VerticalTab(text: e.label)).toList(),
@@ -78,7 +75,7 @@ class _RankPageState extends State<RankPage>
               ..tabController.animateTo(index);
           }
         },
-      );
-    });
+      ),
+    );
   }
 }

--- a/lib/pages/rank/zone/view.dart
+++ b/lib/pages/rank/zone/view.dart
@@ -1,4 +1,3 @@
-import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
 import 'package:PiliPlus/common/widgets/native_top_spacer.dart';
 import 'package:PiliPlus/common/widgets/video_card/video_card_h.dart';
@@ -39,7 +38,7 @@ class _ZonePageState extends State<ZonePage>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return refreshIndicator(
+    return NativeTopRefreshIndicator(
       onRefresh: controller.onRefresh,
       child: CustomScrollView(
         controller: controller.scrollController,

--- a/lib/pages/rcmd/view.dart
+++ b/lib/pages/rcmd/view.dart
@@ -1,7 +1,6 @@
 import 'package:PiliPlus/common/skeleton/video_card_v.dart';
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/common/widgets/native_top_spacer.dart';
-import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
 import 'package:PiliPlus/common/widgets/video_card/video_card_v.dart';
 import 'package:PiliPlus/http/loading_state.dart';
@@ -57,7 +56,7 @@ class _RcmdPageState extends State<RcmdPage>
       clipBehavior: OS.isHarmony ? Clip.none : Clip.hardEdge,
       margin: const EdgeInsets.symmetric(horizontal: Style.safeSpace),
       decoration: const BoxDecoration(borderRadius: Style.mdRadius),
-      child: refreshIndicator(
+      child: NativeTopRefreshIndicator(
         onRefresh: controller.onRefresh,
         child: CustomScrollView(
           controller: controller.scrollController,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1244,7 +1244,7 @@ packages:
     description:
       path: media_kit
       ref: feat-ohos
-      resolved-ref: fc48d2336ac3f25f0c5ea67f9f34d2311f3bdbbe
+      resolved-ref: "30705cfcb605d1e911d0d15635216b7285464214"
       url: "https://github.com/cnoim/media-kit.git"
     source: git
     version: "1.2.3"
@@ -1262,7 +1262,7 @@ packages:
     description:
       path: "libs/ios/media_kit_libs_ios_video"
       ref: feat-ohos
-      resolved-ref: fc48d2336ac3f25f0c5ea67f9f34d2311f3bdbbe
+      resolved-ref: "30705cfcb605d1e911d0d15635216b7285464214"
       url: "https://github.com/cnoim/media-kit.git"
     source: git
     version: "1.1.4"
@@ -1271,7 +1271,7 @@ packages:
     description:
       path: "libs/linux/media_kit_libs_linux"
       ref: feat-ohos
-      resolved-ref: fc48d2336ac3f25f0c5ea67f9f34d2311f3bdbbe
+      resolved-ref: "30705cfcb605d1e911d0d15635216b7285464214"
       url: "https://github.com/cnoim/media-kit.git"
     source: git
     version: "1.2.1"
@@ -1280,7 +1280,7 @@ packages:
     description:
       path: "libs/macos/media_kit_libs_macos_video"
       ref: feat-ohos
-      resolved-ref: fc48d2336ac3f25f0c5ea67f9f34d2311f3bdbbe
+      resolved-ref: "30705cfcb605d1e911d0d15635216b7285464214"
       url: "https://github.com/cnoim/media-kit.git"
     source: git
     version: "1.1.4"
@@ -1289,7 +1289,7 @@ packages:
     description:
       path: "libs/ohos/media_kit_libs_ohos"
       ref: feat-ohos
-      resolved-ref: fc48d2336ac3f25f0c5ea67f9f34d2311f3bdbbe
+      resolved-ref: "30705cfcb605d1e911d0d15635216b7285464214"
       url: "https://github.com/cnoim/media-kit.git"
     source: git
     version: "1.0.0"
@@ -1298,7 +1298,7 @@ packages:
     description:
       path: "libs/universal/media_kit_libs_video"
       ref: feat-ohos
-      resolved-ref: fc48d2336ac3f25f0c5ea67f9f34d2311f3bdbbe
+      resolved-ref: "30705cfcb605d1e911d0d15635216b7285464214"
       url: "https://github.com/cnoim/media-kit.git"
     source: git
     version: "1.0.7"
@@ -1325,7 +1325,7 @@ packages:
     description:
       path: media_kit_video
       ref: feat-ohos
-      resolved-ref: fc48d2336ac3f25f0c5ea67f9f34d2311f3bdbbe
+      resolved-ref: "30705cfcb605d1e911d0d15635216b7285464214"
       url: "https://github.com/cnoim/media-kit.git"
     source: git
     version: "2.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
 # update when release
-version: 2.1.0+5584
+version: 2.1.0+5586
 
 environment:
   sdk: ">=3.11.1"


### PR DESCRIPTION
## 问题
均只在开启「鸿蒙沉浸光感顶栏」后出现，关闭该开关不受影响。
1. **首页下拉刷新，转圈被顶栏挡住**——刷新指示器被顶栏沉浸光感效果部分遮挡。
2. **平板横屏时，首页顶部的分类栏（直播/推荐/热门/分区…）整条消失，顶部还留一大片空白**——竖屏正常。

## 原因
两个问题同源：Flutter 侧只看「顶栏开关是否打开」（`MainController.useNativeTopBar`），而 ArkTS 侧顶栏还有自己的显隐规则，两边认知不一致。

**下拉刷新**：窗口是沉浸全屏的（`setWindowLayoutFullScreen(true)`），Flutter 列表顶边就在状态栏下沿，而 ArkTS 顶栏（`Index.ets` 的 `TOP_BAR_EXPANDED_HEIGHT = 144vp`）整个盖在上面。`refreshIndicator` 的 `edgeOffset` 一直是默认 0，转圈就出现在顶栏底下。列表顶部的 `NativeTopSpacer` 只推开了内容，没管指示器。
**横屏分类栏**：横屏走侧栏布局（`useBottomNav == false`），`ShellBarsObserver.onOrientationChanged` 会让 ArkTS 顶栏 `setTopBarHidden(true)`；但 `home/view.dart`、`NativeTopSpacer`、`rank/view.dart` 仍按「顶栏已启用」隐藏自绘分类栏、继续留 85vp 空白，于是分类栏没了、空白还在。
另外 `didChangeDependencies` 里的方向同步被 `if (useNativeTabs.value)` 包着，**只开顶栏、不开底栏**时横屏根本不会通知 ArkTS 隐藏顶栏——这条路径下顶栏会横屏常驻，一并修掉。

## 改动
- **引入「顶栏是否真正生效」的响应式状态**：`MainController.nativeTopBarActive = useNativeTopBar && useBottomNav`。`useBottomNav` 改为带 setter 的属性，横竖屏切换时自动重算；`_initHdsBar` 异步就绪后补算一次。所有布局判断（首页顶栏/分类栏、`NativeTopSpacer.staticHeight`、分区页左侧标签栏 padding）统一改读它，横屏下自然回退成原来的 Flutter 分类栏、留白归零。
- **方向同步不再只看底栏开关**：`useNativeTabs || useNativeTopBar` 任一启用都通知 `ShellBarsObserver`；顶栏 worker 里同样补发一次，覆盖「横屏冷启动、顶栏异步就绪后才知道方向」的路径。
- **下拉刷新指示器避让**：新增 `NativeTopSpacer.refreshEdgeOffset()`，按「顶栏高度（展开 144 / 收起 80）− 状态栏高度」算出 `RefreshIndicator.edgeOffset`，转圈落到顶栏底边下方 `displacement`（移动端默认 20vp）处，与非沉浸页面观感一致。配套新增 `NativeTopRefreshIndicator`，首页 5 个 Tab 列表（推荐/热门/直播/番剧影视/分区）把 `refreshIndicator(` 换成它即可；顶栏未生效时 `edgeOffset` 为 0，与原来完全等价。用 `Obx` 包裹以跟随异步就绪与收起态变化，`child` 由外层 build 构造并被闭包捕获，Obx 重建时是同一个 widget 实例，列表子树不跟着重建。

改动集中在鸿蒙顶栏这条链路上，未开启该功能（含其他平台）的代码路径行为完全不变。

## 行为变化
横屏（侧栏布局）下沉浸光感顶栏统一不生效，首页顶部恢复 Flutter 自绘分类栏——与原生底栏「开启平板适配后横屏不显示」的既有约定保持一致。

## 备注
`144 / 80` 是 Dart 侧对 ArkTS 顶栏高度的镜像常量，已在注释中标注须与 `Index.ets` 的 `TOP_BAR_EXPANDED_HEIGHT / TOP_BAR_COLLAPSED_HEIGHT` 保持一致，以后调顶栏高度需两边一起改。