### PR TITLE
fix(ohos): 重做屏幕方向策略，移除「全向旋转」开关; feat: 设置搜索支持历史记录

### DIFF
--- a/lib/harmony_adapt/harmony_channel.dart
+++ b/lib/harmony_adapt/harmony_channel.dart
@@ -105,6 +105,23 @@ abstract class HarmonyChannel {
     return null;
   }
 
+  /// 系统「自动旋转」开关是否关闭（用户锁定了屏幕旋转）。
+  ///
+  /// 决定播放器全屏时是否强制转屏：
+  /// - 已锁定：系统不会跟着设备转，全屏需按视频方向锁定横/竖轴（轴内仍按重力
+  ///   180° 翻转，用的是不受锁定影响的 AUTO_ROTATION_LANDSCAPE/PORTRAIT）
+  /// - 未锁定：方向交给系统跟随设备，全屏不再强制
+  ///
+  /// 非鸿蒙或读取失败一律按「已锁定」处理（保守，等价旧行为）。
+  static Future<bool> isRotationLocked() async {
+    if (!OS.isHarmony) return true;
+    try {
+      return await _channel.invokeMethod<bool>('isRotationLocked') ?? true;
+    } catch (_) {
+      return true;
+    }
+  }
+
   /// 向原生发送壳配置的公共辅助：非鸿蒙直接跳过，静默失败。
   static Future<void> _invoke(String method, [Map<String, Object?>? args]) async {
     if (!OS.isHarmony) return;
@@ -311,6 +328,13 @@ abstract class HarmonyChannel {
 
   static void autoRotateLandscape() {
     _channel.invokeMethod('autoRotateLandscape');
+  }
+
+  /// 先把窗口转到指定方向，之后继续跟随传感器（USER_ROTATION_*）。
+  /// 用于系统未锁定旋转时进入全屏：点全屏按钮该转到视频方向，转完仍要能
+  /// 跟着设备转回去（转回去会触发页面自动退出全屏）。
+  static void userRotate({required bool landscape}) {
+    _channel.invokeMethod('userRotate', {'landscape': landscape});
   }
 
   /// 自由多窗装饰栏按钮（全屏/最小化/关闭）的颜色跟随应用颜色模式而非

--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -9,7 +9,6 @@ import 'package:PiliPlus/pages/setting/pages/fullscreen_sc_size.dart';
 import 'package:PiliPlus/pages/setting/widgets/select_dialog.dart';
 import 'package:PiliPlus/pages/setting/widgets/slider_dialog.dart';
 import 'package:PiliPlus/plugin/pl_player/models/bottom_progress_behavior.dart';
-import 'package:PiliPlus/plugin/pl_player/utils/fullscreen.dart';
 import 'package:PiliPlus/plugin/pl_player/models/fullscreen_mode.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_repeat.dart';
 import 'package:PiliPlus/services/service_locator.dart';
@@ -205,14 +204,6 @@ List<SettingsModel> get playSettings => [
     leading: Icon(Icons.timer_outlined),
     setKey: SettingBoxKey.enableLongShowControl,
     defaultVal: false,
-  ),
-  SwitchModel(
-    title: '全向旋转',
-    subtitle: '小屏可受重力转为临时全屏，若系统锁定旋转仍触发请关闭，关闭会影响横屏适配',
-    leading: const Icon(Icons.screen_rotation_alt_outlined),
-    setKey: SettingBoxKey.allowRotateScreen,
-    defaultVal: true,
-    onChanged: (value) => allowRotateScreen = value,
   ),
   if (PlatformUtils.isMobile)
     const SwitchModel(

--- a/lib/pages/settings_search/view.dart
+++ b/lib/pages/settings_search/view.dart
@@ -1,6 +1,8 @@
-﻿import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
+import 'package:PiliPlus/common/widgets/dialog/dialog.dart';
+import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
 import 'package:PiliPlus/common/widgets/view_sliver_safe_area.dart';
 import 'package:PiliPlus/pages/search/controller.dart' show DebounceStreamState;
+import 'package:PiliPlus/pages/search/widgets/search_text.dart';
 import 'package:PiliPlus/pages/setting/models/experimental_settings.dart';
 import 'package:PiliPlus/pages/setting/models/extra_settings.dart';
 import 'package:PiliPlus/pages/setting/models/model.dart';
@@ -10,6 +12,7 @@ import 'package:PiliPlus/pages/setting/models/recommend_settings.dart';
 import 'package:PiliPlus/pages/setting/models/style_settings.dart';
 import 'package:PiliPlus/pages/setting/models/video_settings.dart';
 import 'package:PiliPlus/utils/grid.dart';
+import 'package:PiliPlus/utils/storage.dart';
 import 'package:PiliPlus/utils/waterfall.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -25,8 +28,16 @@ class SettingsSearchPage extends StatefulWidget {
 
 class _SettingsSearchPageState
     extends DebounceStreamState<SettingsSearchPage, String> {
+  /// 与主搜索共用 historyWord 盒子，另起 key 互不干扰
+  static const String _historyKey = 'settingsSearchWord';
+  static const int _maxHistory = 20;
+
   final _textEditingController = TextEditingController();
   final RxList<SettingsModel> _list = <SettingsModel>[].obs;
+  final RxString _keyword = ''.obs;
+  late final RxList<String> _history = RxList<String>.from(
+    GStorage.historyWord.get(_historyKey) ?? const <String>[],
+  );
   late final _settings = [
     ...extraSettings,
     ...privacySettings,
@@ -39,6 +50,7 @@ class _SettingsSearchPageState
 
   @override
   void onValueChanged(String value) {
+    _keyword.value = value;
     if (value.isEmpty) {
       _list.clear();
     } else {
@@ -53,22 +65,65 @@ class _SettingsSearchPageState
     }
   }
 
+  /// 设置搜索是输入即过滤、没有「提交搜索」这一步，故只在离开页面、清空输入
+  /// 和按下回车时记录当次的最终关键词——逐次输入都记会把中间前缀（「弹」
+  /// 「弹幕」…）全存进去。
+  void _saveHistory([String? word]) {
+    final text = (word ?? _textEditingController.text).trim();
+    if (text.isEmpty) return;
+    _history
+      ..remove(text)
+      ..insert(0, text);
+    if (_history.length > _maxHistory) {
+      _history.removeRange(_maxHistory, _history.length);
+    }
+    GStorage.historyWord.put(_historyKey, _history);
+  }
+
+  void _onTapHistory(String word) {
+    _textEditingController
+      ..text = word
+      ..selection = TextSelection.collapsed(offset: word.length);
+    // 直接过滤，不等防抖
+    onValueChanged(word);
+  }
+
+  void _onLongPressHistory(String word) {
+    _history.remove(word);
+    GStorage.historyWord.put(_historyKey, _history);
+  }
+
+  void _onClearHistory() {
+    showConfirmDialog(
+      context: context,
+      title: const Text('确定清空搜索历史？'),
+      onConfirm: () {
+        _history.clear();
+        GStorage.historyWord.delete(_historyKey);
+      },
+    );
+  }
+
   @override
   void dispose() {
+    _saveHistory();
     _textEditingController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(
         actions: [
           IconButton(
             onPressed: () {
               if (_textEditingController.text.isNotEmpty) {
+                _saveHistory();
                 _textEditingController.clear();
                 _list.clear();
+                _keyword.value = '';
               } else {
                 Get.back();
               }
@@ -82,6 +137,7 @@ class _SettingsSearchPageState
           controller: _textEditingController,
           textAlignVertical: TextAlignVertical.center,
           onChanged: ctr!.add,
+          onSubmitted: _saveHistory,
           decoration: const InputDecoration(
             isDense: true,
             hintText: '搜索',
@@ -93,19 +149,91 @@ class _SettingsSearchPageState
       body: CustomScrollView(
         slivers: [
           ViewSliverSafeArea(
-            sliver: Obx(
-              () => _list.isEmpty
-                  ? const HttpError()
-                  : SliverWaterfallFlow(
-                      gridDelegate:
-                          SliverWaterfallFlowDelegateWithMaxCrossAxisExtent(
-                            maxCrossAxisExtent: Grid.smallCardWidth * 2,
-                          ),
-                      delegate: SliverChildBuilderDelegate(
-                        (_, index) => _list[index].widget,
-                        childCount: _list.length,
+            sliver: Obx(() {
+              if (_list.isNotEmpty) {
+                return SliverWaterfallFlow(
+                  gridDelegate:
+                      SliverWaterfallFlowDelegateWithMaxCrossAxisExtent(
+                        maxCrossAxisExtent: Grid.smallCardWidth * 2,
                       ),
+                  delegate: SliverChildBuilderDelegate(
+                    (_, index) => _list[index].widget,
+                    childCount: _list.length,
+                  ),
+                );
+              }
+              // 关键词为空时展示历史；有关键词却没结果才是「无结果」
+              return _keyword.value.isEmpty
+                  ? _buildHistory(theme)
+                  : const HttpError();
+            }),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHistory(ThemeData theme) {
+    if (_history.isEmpty) {
+      return const SliverToBoxAdapter();
+    }
+    final secondary = theme.colorScheme.secondary;
+    return SliverPadding(
+      padding: const EdgeInsets.fromLTRB(16, 10, 10, 25),
+      sliver: SliverMainAxisGroup(
+        slivers: [
+          SliverToBoxAdapter(
+            child: Row(
+              children: [
+                Text(
+                  '搜索历史',
+                  strutStyle: const StrutStyle(leading: 0, height: 1),
+                  style: theme.textTheme.titleMedium!.copyWith(
+                    height: 1,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const Spacer(),
+                TextButton.icon(
+                  style: const ButtonStyle(
+                    visualDensity: VisualDensity.compact,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    padding: WidgetStatePropertyAll(
+                      EdgeInsets.symmetric(horizontal: 10),
                     ),
+                  ),
+                  onPressed: _onClearHistory,
+                  icon: Icon(
+                    Icons.clear_all_outlined,
+                    size: 18,
+                    color: secondary,
+                  ),
+                  label: Text(
+                    '清空',
+                    style: TextStyle(fontSize: 13, color: secondary),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 4, right: 6),
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: _history
+                    .map(
+                      (item) => SearchText(
+                        text: item,
+                        fontSize: 14,
+                        height: 1,
+                        onTap: _onTapHistory,
+                        onLongPress: _onLongPressHistory,
+                      ),
+                    )
+                    .toList(),
+              ),
             ),
           ),
         ],

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -163,6 +163,8 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
       hideSystemBar();
     }
 
+    _unlockOrientation();
+
     if (videoDetailController.showReply) {
       _videoReplyController = Get.put(
         VideoReplyController(
@@ -360,6 +362,9 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
   void dispose() {
     _pipModeWorker?.dispose();
     HarmonyChannel.releaseDecorDark(this);
+    // 播放器 dispose 里的 resetScreenRotation 只在播放器真正销毁时才走到
+    // （isCloseAll / 多开引用未清零时会跳过），这里按页面生命周期兜底恢复
+    _lockOrientation();
     plPlayerController
       ?..removeStatusLister(playerListener)
       ..removePositionListener(positionListener);
@@ -415,6 +420,11 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
     HarmonyChannel.releaseDecorDark(this);
     WidgetsBinding.instance.removeObserver(this);
 
+    // 全屏（横屏）时压栈不锁方向，否则会把用户从横屏硬拽回竖屏
+    if (!isFullScreen) {
+      _lockOrientation();
+    }
+
     if ((Platform.isAndroid || OS.isHarmony) &&
         !videoDetailController.setSystemBrightness) {
       ScreenBrightnessPlatform.instance.resetApplicationScreenBrightness();
@@ -447,6 +457,8 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
 
     HarmonyChannel.holdDecorDark(this);
     WidgetsBinding.instance.addObserver(this);
+
+    _unlockOrientation();
 
     plPlayerController?.isLive = false;
     if (videoDetailController.plPlayerController.playerStatus.isPlaying &&
@@ -522,6 +534,64 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
     themeData = videoDetailController.plPlayerController.darkVideoPage
         ? ThemeUtils.darkTheme
         : Theme.of(context);
+  }
+
+  /// 当前放开着方向的播放页数量。视频页可以叠栈（视频里再点视频），用计数避免
+  /// 上层页面 dispose 时把下层仍需要的方向锁回去，也不受两页 initState/dispose
+  /// 先后顺序的影响。
+  static int _orientationHolders = 0;
+  bool _holdsOrientation = false;
+
+  /// 关闭横屏适配时，应用启动即被锁死 portraitUp（见 main.dart），窗口永远不会
+  /// 转成横屏，下面 [childWhenDisabled] 里「窗口变横屏 → 自动进全屏 / 转回竖屏
+  /// → 自动退全屏」那段逻辑因此永远走不到，表现为转动设备毫无反应。
+  ///
+  /// 这里在播放页存续期间改用 [deviceAutoMode]（四方向、但受系统旋转锁定控制）：
+  /// 系统锁了旋转就停在竖屏，没锁就跟着设备转——正是「除播放页外一律竖屏、
+  /// 播放页跟随设备」这条预期。开启横屏适配时应用全局已是跟随系统，不必接管。
+  void _unlockOrientation() {
+    if (!PlatformUtils.isMobile || videoDetailController.horizontalScreen) {
+      return;
+    }
+    // 退出全屏时回到页面级方向，而不是被锁回竖屏。每次回到本页都重新登记：
+    // 叠栈时上层页面 dispose 会把登记清掉（播放器是单例，共用这一个字段）
+    videoDetailController.plPlayerController.restorePageOrientation =
+        _restorePageOrientation;
+    if (_holdsOrientation) return;
+    _holdsOrientation = true;
+    if (++_orientationHolders == 1) {
+      deviceAutoMode();
+    }
+  }
+
+  /// 离开播放页时恢复竖屏锁，别把放开的方向带到其他页面
+  void _lockOrientation() {
+    if (!_holdsOrientation) return;
+    _holdsOrientation = false;
+    final player = videoDetailController.plPlayerController;
+    if (player.restorePageOrientation == _restorePageOrientation) {
+      player.restorePageOrientation = null;
+    }
+    if (--_orientationHolders == 0) {
+      portraitUpMode();
+    }
+  }
+
+  /// 退出全屏后的页面级方向，两种情况都要先回到竖屏——关闭横屏适配时详情页
+  /// 没有横屏布局，留在横屏会被 [childWhenDisabled] 立刻自动重进全屏，表现为
+  /// 「点退出/侧滑返回后闪一下又回到全屏」，只能靠把设备转竖才退得出去。
+  ///
+  /// - 系统锁了旋转：直接转回竖屏（全屏期间已被转到横屏，[deviceAutoMode]
+  ///   只会原地冻结在横屏）
+  /// - 未锁定：用 USER_ROTATION_PORTRAIT「先转回竖屏、之后再跟随传感器」。
+  ///   这里不能用 [deviceAutoMode]：设备此刻多半还横着拿，立刻跟随设备就又
+  ///   转回横屏了。USER_ROTATION_* 转过去后要等下一次传感器变化才继续跟随，
+  ///   正好把「按设备方向判断」推迟到用户真的动了设备之后。
+  Future<void>? _restorePageOrientation() async {
+    if (await HarmonyChannel.isRotationLocked()) {
+      return portraitUpMode();
+    }
+    return userRotateMode(landscape: false);
   }
 
   bool removeAppBar(bool isFullScreen) =>

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1555,26 +1555,46 @@ class PlPlayerController with BlockConfigMixin {
 
   double screenRatio = 0.0;
   bool isManualFS = true;
-  late final FullScreenMode mode = Pref.fullScreenMode;
+  // 每次读取而不缓存：播放器是跨页面存活的单例，缓存会让在设置页改完
+  // 「默认全屏方向」后本次会话仍用旧值，表现为「改了没反应」
+  FullScreenMode get mode => Pref.fullScreenMode;
   late final horizontalScreen = Pref.horizontalScreen;
   late final removeSafeArea = Pref.removeSafeArea;
 
   Future<void>? changeOrientation({
     required bool isVertical,
     DeviceOrientation? orientation,
-  }) {
+  }) async {
     if (orientation == null && mode == .none) {
-      return null;
+      return;
     }
     if (orientation == null && mode == .gravity) {
       // 上游的 gravity 依赖方向监听器主动转屏，鸿蒙无该插件，改为放开四方向交给系统
       return OS.isHarmony ? harmonyFullAutoMode() : null;
     }
-    if (orientation == null &&
+    final bool toPortrait =
+        orientation == null &&
         (mode == .vertical ||
             (mode == .auto && isVertical) ||
-            (mode == .ratio && (isVertical || screenRatio < kScreenRatio)))) {
-      return portraitUpMode();
+            (mode == .ratio && (isVertical || screenRatio < kScreenRatio)));
+    // 自适应类模式下，若系统开着自动旋转，就不把方向轴锁死：先转到视频方向
+    // （点全屏按钮该有的反应），转完继续跟随设备，转回另一方向时页面会自动
+    // 退出全屏。「强制竖屏 / 强制横屏」是显式指定，始终锁轴，不走这里。
+    if (orientation == null &&
+        (mode == .auto || mode == .ratio) &&
+        !await HarmonyChannel.isRotationLocked()) {
+      // 窗口已经在目标方向轴上就别动：USER_ROTATION_* 是「先转到该轴的默认
+      // 朝向、之后再跟随传感器」，此时下发会把已经跟着设备转好的朝向硬掰回
+      // 默认朝向（横屏即左边在下），要等下一次传感器变化才纠正回来。
+      // screenRatio = 窗口高/宽，由播放页在尺寸变化时同步，0 表示尚未拿到。
+      if (screenRatio > 0 && (screenRatio < 1) != toPortrait) {
+        return;
+      }
+      return userRotateMode(landscape: !toPortrait);
+    }
+    if (toPortrait) {
+      // 锁定竖屏轴，轴内仍按重力 180° 翻转
+      return portraitAxisMode();
     } else {
       // 鸿蒙拿不到设备朝向（无 native_device_orientation），不能像下面那样锁定单一
       // 横屏方向，否则只能朝一边转。交给系统在左右横屏间按重力自动切换。
@@ -1632,7 +1652,7 @@ class PlPlayerController with BlockConfigMixin {
           if (orientation == null && mode == .none) {
             return;
           }
-          await resetScreenRotation();
+          await (restorePageOrientation ?? resetScreenRotation)();
         } else {
           await exitDesktopFullScreen();
         }
@@ -1733,6 +1753,12 @@ class PlPlayerController with BlockConfigMixin {
   // isCloseAll 由外部页面直接置位（新 ohos 提交的写法），故为公开字段
   bool isCloseAll = false;
 
+  /// 退出全屏后恢复的「页面级方向」。由播放页在存续期间注册（见
+  /// video/view.dart）：关闭横屏适配时页面本身也要跟随设备方向，不能像
+  /// 播放器销毁那样直接锁回竖屏。未注册时退回 [resetScreenRotation]。
+  Future<void>? Function()? restorePageOrientation;
+
+  /// 播放器销毁时恢复应用级方向：开着横屏适配跟随系统，否则锁回竖屏
   Future<void>? resetScreenRotation() {
     if (horizontalScreen) {
       return fullMode();

--- a/lib/plugin/pl_player/utils/fullscreen.dart
+++ b/lib/plugin/pl_player/utils/fullscreen.dart
@@ -3,8 +3,6 @@ import 'dart:io' show Platform;
 
 import 'package:PiliPlus/harmony_adapt/harmony_channel.dart';
 import 'package:PiliPlus/utils/device_utils.dart';
-import 'package:PiliPlus/utils/platform_utils.dart';
-import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:auto_orientation/auto_orientation.dart';
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter/services.dart'
@@ -37,9 +35,6 @@ Future<void> exitDesktopFullScreen() async {
   }
 }
 
-// 全向旋转开关（鸿蒙/安卓），由播放器设置页写入
-bool allowRotateScreen = Pref.allowRotateScreen;
-
 List<DeviceOrientation>? _lastOrientation;
 Future<void>? _setPreferredOrientations(List<DeviceOrientation> orientations) {
   if (_lastOrientation == orientations) {
@@ -66,6 +61,42 @@ Future<void> harmonyFullAutoMode() {
   return AutoOrientation.fullAutoMode();
 }
 
+/// 页面级「跟随设备方向」：四个方向按重力旋转，但**受系统旋转锁定控制**——
+/// 用户锁了旋转就保持当前方向不动。关闭横屏适配时的视频详情页用它，从而
+/// 「系统锁定 → 停在竖屏」「系统未锁定 → 跟着设备转」两种预期各自成立。
+///
+/// 鸿蒙走 AUTO_ROTATION_RESTRICTED（auto_orientation 的 fullAutoMode，
+/// 名字叫 full 其实是受开关控制的版本）。
+Future<void>? deviceAutoMode() {
+  if (OS.isHarmony) {
+    _invalidateOrientationCache();
+    return AutoOrientation.fullAutoMode();
+  }
+  return _setPreferredOrientations(
+    const [.portraitUp, .portraitDown, .landscapeLeft, .landscapeRight],
+  );
+}
+
+/// 全屏用：锁定竖屏轴，轴内按重力 180° 翻转，且不受系统旋转锁定影响
+/// （鸿蒙 AUTO_ROTATION_PORTRAIT）。其他平台没有等价语义，退化为固定竖屏。
+Future<void>? portraitAxisMode() {
+  if (OS.isHarmony) {
+    _invalidateOrientationCache();
+    return AutoOrientation.portraitAutoMode();
+  }
+  return portraitUpMode();
+}
+
+/// 全屏用（系统未锁定旋转时）：先转到视频所在的方向，转完继续跟随设备。
+/// 既保证点全屏按钮会转屏，又保留「转回另一方向 → 自动退出全屏」的手感；
+/// 锁死方向轴的 [portraitAxisMode] / [harmonyLandscapeAutoMode] 做不到后者。
+Future<void>? userRotateMode({required bool landscape}) {
+  if (!OS.isHarmony) return null;
+  _invalidateOrientationCache();
+  HarmonyChannel.userRotate(landscape: landscape);
+  return null;
+}
+
 /// 上面两个走的都是原生 window.setPreferredOrientation / auto_orientation 插件，
 /// 绕过了 SystemChrome，[_lastOrientation] 不会更新。必须显式作废缓存，否则退出全屏时
 /// [_setPreferredOrientations] 会误判「方向没变」而跳过，把屏幕卡在横屏。
@@ -87,11 +118,9 @@ Future<void>? landscapeRightMode() {
   return _setPreferredOrientations(const [.landscapeRight]);
 }
 
+/// 应用级「跟随系统」：开启横屏适配时的全局方向，方向由系统按设备朝向判定，
+/// 受系统旋转锁定控制（锁定 → 系统决定锁成竖屏还是横屏；未锁定 → 跟随设备）。
 Future<void>? fullMode() {
-  // 鸿蒙/安卓上「全向旋转」关闭时不放开自由旋转，等价于原 autoScreen() 的行为
-  if (PlatformUtils.isMobile && !allowRotateScreen) {
-    return null;
-  }
   final result = _setPreferredOrientations(
     const [.portraitUp, .portraitDown, .landscapeLeft, .landscapeRight],
   );

--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -4,12 +4,15 @@ import 'dart:typed_data';
 import 'package:PiliPlus/models/model_owner.dart';
 import 'package:PiliPlus/models/user/danmaku_rule_adapter.dart';
 import 'package:PiliPlus/models/user/info.dart';
+import 'package:PiliPlus/plugin/pl_player/models/fullscreen_mode.dart';
 import 'package:PiliPlus/utils/accounts.dart';
 import 'package:PiliPlus/utils/accounts/account_adapter.dart';
 import 'package:PiliPlus/utils/accounts/account_type_adapter.dart';
 import 'package:PiliPlus/utils/accounts/cookie_jar_adapter.dart';
+import 'package:PiliPlus/utils/device_utils.dart';
 import 'package:PiliPlus/utils/path_utils.dart';
 import 'package:PiliPlus/utils/set_int_adapter.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:PiliPlus/utils/utils.dart';
 import 'package:hive_ce/hive.dart';
@@ -64,6 +67,8 @@ abstract final class GStorage {
       ).then((res) => watchProgress = res),
     ]);
 
+    _migrateFullScreenMode();
+
     if (Pref.saveReply) {
       reply = await Hive.openBox<Uint8List>(
         'reply',
@@ -74,6 +79,19 @@ abstract final class GStorage {
       );
     } else {
       reply = null;
+    }
+  }
+
+  /// 一次性迁移：旧版本的 Pref.fullScreenMode 会把按「平板 + 横屏适配」推导出的
+  /// 默认值落库，平板上即「不改变当前方向」。它一旦被冻结，之后无论开关怎么调，
+  /// 点全屏按钮都不会按视频方向转屏。这里把平板上的该值清掉，让它回到新的默认值
+  /// 「按视频方向」；手机上的「不改变当前方向」只可能是用户显式选的，不动。
+  static void _migrateFullScreenMode() {
+    if (setting.get(SettingBoxKey.fullScreenModeMigrated) == true) return;
+    setting.put(SettingBoxKey.fullScreenModeMigrated, true);
+    if (DeviceUtils.isTablet &&
+        setting.get(SettingBoxKey.fullScreenMode) == FullScreenMode.none.index) {
+      setting.delete(SettingBoxKey.fullScreenMode);
     }
   }
 

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -161,7 +161,8 @@ abstract final class SettingBoxKey {
       floatingNavBar = 'floatingNavBar',
       removeSafeArea = 'removeSafeArea',
       angleDegrees = 'angleDegrees',
-      allowRotateScreen = 'allowRotateScreen',
+      // 全屏方向旧默认值（平板 + 横屏适配 → 不改变当前方向）的一次性迁移标记
+      fullScreenModeMigrated = 'fullScreenModeMigrated',
       liveStream = 'liveStream';
 
   static const String minimizeOnExit = 'minimizeOnExit',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -194,14 +194,14 @@ abstract final class Pref {
         defaultValue: UpPanelPosition.leftFixed.index,
       )];
 
+  /// 默认「按视频方向」：全屏方向该锁哪条轴只跟视频有关，与是否平板、是否开
+  /// 横屏适配无关（那两者决定的是页面方向，见 fullscreen.dart 的各 mode）。
+  /// 旧版本会按「平板 + 横屏适配」推导出 .none 并落库，冻结后点全屏永远不转屏，
+  /// 已由 GStorage.init 中的一次性迁移清除。
   static FullScreenMode get fullScreenMode {
     int? index = _setting.get(SettingBoxKey.fullScreenMode);
     if (index == null) {
-      final FullScreenMode mode = horizontalScreen && DeviceUtils.isTablet
-          ? .none
-          : .auto;
-      _setting.put(SettingBoxKey.fullScreenMode, mode.index);
-      return mode;
+      return .auto;
     }
     return FullScreenMode.values[index];
   }
@@ -1030,10 +1030,6 @@ abstract final class Pref {
 
   // 竖向滚动 slop 已在 main._builder 统一为 8 逻辑像素（鸿蒙），横向取 12
   // 时约 34° 以内的滑动可赢得竞技场，横竖手势按主导方向竞争。
-  // 鸿蒙/安卓全向旋转开关
-  static bool get allowRotateScreen =>
-      _setting.get(SettingBoxKey.allowRotateScreen, defaultValue: true);
-
   static double get touchSlopH =>
       _setting.get(SettingBoxKey.touchSlopH, defaultValue: 12.0);
 

--- a/ohos/entry/src/main/ets/plugins/HarmonyChannel.ets
+++ b/ohos/entry/src/main/ets/plugins/HarmonyChannel.ets
@@ -4,6 +4,7 @@ import AbilityConstant from "@ohos.app.ability.AbilityConstant";
 import Want from "@ohos.app.ability.Want";
 import ConfigurationConstant from "@ohos.app.ability.ConfigurationConstant";
 import deviceInfo from "@ohos.deviceInfo";
+import settings from "@ohos.settings";
 import { backgroundTaskManager } from "@kit.BackgroundTasksKit";
 import window from "@ohos.window";
 import {
@@ -74,6 +75,12 @@ export default class HarmonyChannel implements FlutterPlugin {
         await this.autoRotateLandscape();
         result.success(true);
         break;
+      case "userRotate": {
+        const toLandscape: boolean = call.argument("landscape") ?? false;
+        await this.userRotate(toLandscape);
+        result.success(true);
+        break;
+      }
       case "setDecorButtonDark": {
         const dark: boolean = call.argument("dark") ?? false;
         await this.setDecorButtonDark(dark);
@@ -98,6 +105,10 @@ export default class HarmonyChannel implements FlutterPlugin {
       }
       case "getDeviceInfo": {
         result.success({ sdkApiVersion: deviceInfo.sdkApiVersion });
+        break;
+      }
+      case "isRotationLocked": {
+        result.success(this.isRotationLocked());
         break;
       }
       case "setShellBars": {
@@ -215,6 +226,28 @@ export default class HarmonyChannel implements FlutterPlugin {
       default:
         result.notImplemented();
         break;
+    }
+  }
+
+  /**
+   * 系统「自动旋转」开关是否关闭（即用户锁定了屏幕旋转）。
+   *
+   * ACCELEROMETER_ROTATION_STATUS：'1' 表示使用重力传感器改变屏幕方向，
+   * '0' 表示锁定。读不到（键不存在/取值异常）时一律按「已锁定」处理：
+   * 锁定分支会按视频方向强制转屏，是保守且与旧版本一致的行为；反过来误判
+   * 成未锁定会导致横屏视频点全屏后既不转屏也转不动，问题严重得多。
+   */
+  private isRotationLocked(): boolean {
+    try {
+      const value = settings.getValueSync(
+        getContext(),
+        settings.general.ACCELEROMETER_ROTATION_STATUS,
+        '0',
+      );
+      return value !== '1';
+    } catch (err) {
+      console.error("HarmonyChannel", `read rotation lock failed: ${err}`);
+      return true;
     }
   }
 
@@ -386,6 +419,21 @@ export default class HarmonyChannel implements FlutterPlugin {
   async autoRotateLandscape() {
     this.lastWindow ??= await window.getLastWindow(getContext());
     this.lastWindow.setPreferredOrientation(window.Orientation.AUTO_ROTATION_LANDSCAPE)
+  }
+
+  /**
+   * 先转到指定方向，之后继续跟随传感器（受系统旋转开关控制）。
+   * 系统未锁定旋转时进入全屏用：点全屏按钮要转到视频方向，转完仍能跟着
+   * 设备转回去。锁定旋转的场景不用它——那时需要的是不受开关控制的
+   * AUTO_ROTATION_LANDSCAPE/PORTRAIT。
+   */
+  async userRotate(landscape: boolean) {
+    this.lastWindow ??= await window.getLastWindow(getContext());
+    this.lastWindow.setPreferredOrientation(
+      landscape
+        ? window.Orientation.USER_ROTATION_LANDSCAPE
+        : window.Orientation.USER_ROTATION_PORTRAIT
+    );
   }
 
   /**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
 # update when release
-version: 2.1.0+5586
+version: 2.1.0+5589
 
 environment:
   sdk: ">=3.11.1"


### PR DESCRIPTION
## 一、屏幕方向
上游已移除「全向旋转」开关，本 PR 同步移除，并把方向逻辑按「系统旋转锁定 × 横屏适配」重新梳理了一遍。目标行为：

| # | 系统旋转锁定 | 横屏适配 | 期望 |
| --- | --- | --- | --- |
| 1 | 开 | 关 | 除全屏播放页外（含视频详情页）一律竖屏；点全屏按钮后按视频方向进入横/竖屏全屏，且轴内能随设备 180° 翻转 |
| 2 | 关 | 关 | 视频详情页跟随设备方向旋转，与是否全屏、是否正在播放无关；其余页面竖屏 |
| 3 | 开 | 开 | 除全屏播放页外（含视频详情页）由系统按设备方向决定锁竖屏还是横屏；全屏同第 1 条 |
| 4 | 关 | 开 | 任何页面都跟随设备方向 |

原实现做不到这些，根因有三个：
- **关闭横屏适配时应用启动即被锁死 `portraitUp`**（main.dart），窗口永远不会转成横屏，导致 `video/view.dart` 里「窗口变横屏 → 自动进全屏 / 转回竖屏 → 自动退全屏」那段逻辑成了死代码，播放时转动设备毫无反应。
- **全屏方向的默认值被冻结**：`Pref.fullScreenMode` 会把按「平板 + 横屏适配」推导出的默认值**落库**，平板上即「不改变当前方向」。一旦冻结，之后无论开关怎么调，点全屏都不再按视频方向转屏（第 1、3 条直接不成立）。
- 方向切换只用了「固定方向」和「横屏轴自动旋转」两种模式，无法表达「受系统旋转锁定控制」这一层语义。

### 实现
把方向拆成**页面级**与**全屏级**两层，各自选用语义精确的鸿蒙 `window.Orientation`：
| 场景 | 使用的方向模式 | 是否受系统旋转锁定影响 |
| --- | --- | --- |
| 横屏适配开（应用级） | `AUTO_ROTATION_UNSPECIFIED` | 受控，方向由系统判定 |
| 横屏适配关 · 视频详情页 | `AUTO_ROTATION_RESTRICTED` | 受控，锁定时保持当前方向（即竖屏） |
| 横屏适配关 · 其他页面 | `PORTRAIT` | 固定竖屏 |
| 全屏 · 系统已锁定旋转 | `AUTO_ROTATION_LANDSCAPE` / `AUTO_ROTATION_PORTRAIT` | **不受控**，锁轴 + 轴内 180° 跟重力 |
| 全屏 · 系统未锁定旋转 | `USER_ROTATION_LANDSCAPE` / `USER_ROTATION_PORTRAIT` | 受控，先转到视频方向，之后继续跟随设备 |

要点：
- **新增系统旋转锁定查询**：ArkTS 侧读 `settings.general.ACCELEROMETER_ROTATION_STATUS`，Dart 侧 `HarmonyChannel.isRotationLocked()`。非鸿蒙或读取失败一律按「已锁定」兜底——该分支按视频方向强制转屏，与旧行为一致；反向误判会导致横屏视频点全屏后既不转屏也转不动，后果严重得多。
- **未锁定时不锁死方向轴**：用 `USER_ROTATION_*`（先转到视频方向、之后跟随传感器），既保留「点全屏就转过去」的常规手感，又满足第 2、4 条的「跟随设备」。「强制竖屏 / 强制横屏」是用户显式指定，始终锁轴，不走这条规则。
- **窗口已在目标方向轴上时不下发转屏**：`USER_ROTATION_*` 是「先转到该轴的**默认**朝向再跟随传感器」，页面已经跟着设备转成「右边在下」时下发会被硬掰回「左边在下」，且要等下一次传感器变化才纠正。判据用现成的 `screenRatio`（窗口高/宽，播放页在尺寸变化时同步）。
- **视频详情页接管页面级方向**：进入/返回页面放开为 `AUTO_ROTATION_RESTRICTED`，离开/销毁锁回竖屏；叠栈（视频里再点视频）用计数保护，不受两页 initState/dispose 先后顺序影响。
- **退出全屏先回竖屏**：关闭横屏适配时详情页没有横屏布局，设备横着拿时退出全屏会被「窗口是横屏 → 自动进全屏」立刻推回去，表现为点退出/侧滑返回后闪一下又回到全屏，只能把设备转竖才出得来。改为退出时用 `USER_ROTATION_PORTRAIT` 先转回竖屏，它转到目标方向后要等下一次传感器变化才继续跟随，正好把「按设备方向判断」推迟到用户真的动了设备之后。退出按钮与侧滑返回共用此路径（全屏下侧滑返回在 `onPopInvokedWithResult` 里被转成 `triggerFullScreen(status: false)`）。
- **全屏方向默认值改为一律「按视频方向」且不再落库**，并在 `GStorage.init` 加了一次性迁移（`fullScreenModeMigrated` 标记）：清除平板上已被冻结的「不改变当前方向」。手机上的该值只可能是用户显式选的，不动。
- **`PlPlayerController.mode` 由 `late final` 改为 getter**：播放器是跨页面存活的单例，缓存会让在设置页改完「默认全屏方向」后本次会话仍用旧值，表现为「改了没反应」。
- **移除「全向旋转」**：设置项、`Pref.allowRotateScreen`、`SettingBoxKey.allowRotateScreen` 及 `fullMode()` 里的门槛判断一并删除。

### 已知取舍
- 手机系统层面无法把屏幕锁定在横屏，因此第 3 条在手机上只会得到竖屏。这正是「旋转锁定」在手机上的定义，未做绕过；同一份代码在平板上（系统可把锁定状态保持在横屏）会给出预期行为。
- 手动进入全屏后把设备转回另一方向不会自动退出全屏（自动退出只对转屏触发的全屏生效），会得到「竖屏全屏」。保持了 `isManualFS` 的既有语义。
- 直播页未接管页面级方向，行为与改动前一致。

## 二、设置搜索历史

设置页的搜索此前没有历史记录，每次进入都是空白页。现补上：
- 与主搜索共用 `historyWord` 盒子、另起 key（`settingsSearchWord`），互不干扰；上限 20 条。
- 设置搜索是输入即过滤、没有「提交搜索」这一步，故只在**离开页面、清空输入框、按下回车**时记录当次的最终关键词——逐次输入都记会把中间前缀（「弹」「弹幕」…）全存进去。
- 关键词为空时展示历史，有关键词却无结果才显示「无结果」（此前空关键词也显示无结果占位）。
- 点击历史词直接回填并立即过滤（不等防抖），长按删除单条，右上角「清空」带二次确认——交互与主搜索页保持一致，复用 `SearchText` 组件。
