### PR TITLE
fix(harmony): 修复移除播放页安全边距后状态栏显隐错位

### DIFF
--- a/lib/harmony_adapt/shell_bars_observer.dart
+++ b/lib/harmony_adapt/shell_bars_observer.dart
@@ -1,4 +1,6 @@
 import 'package:PiliPlus/harmony_adapt/harmony_channel.dart';
+import 'package:PiliPlus/common/widgets/image_viewer/hero_dialog_route.dart';
+import 'package:PiliPlus/plugin/pl_player/utils/fullscreen.dart';
 import 'package:flutter/material.dart';
 
 /// 监听全局路由变化，自动控制 ArkTS HDS 底栏的显隐。
@@ -50,5 +52,20 @@ class ShellBarsObserver extends NavigatorObserver {
     // 直接隐藏而绕过宽高比分流。
     final hasPageOverlay = _activeRoutes.whereType<PageRoute>().length > 1;
     HarmonyChannel.setTopBarHidden(hasPageOverlay || _orientationHidden);
+    // 系统状态栏跟随「最上层页面是否仍是沉浸播放页」，与原生顶栏同频：
+    // - 最上层是视频/直播播放页（/videoV、/liveRoom）：保持沉浸，不干预
+    // - 最上层是普通整页（含播放页 → UP 主主页 → 再进播放页 → 返回等嵌套
+    //   场景）：立即恢复状态栏，避免新页面继承播放页的沉浸状态
+    // - 图片查看器（HeroDialogRoute）自带状态栏逻辑，跳过
+    final pageRoutes = _activeRoutes.whereType<PageRoute>().toList();
+    final topPage = pageRoutes.isEmpty ? null : pageRoutes.last;
+    final topIsPlayer = topPage != null &&
+        (topPage.settings.name == '/videoV' ||
+            topPage.settings.name == '/liveRoom');
+    if (!_orientationHidden &&
+        (topPage == null || !topIsPlayer) &&
+        topPage is! HeroDialogRoute) {
+      restoreSystemBarIfHidden();
+    }
   }
 }

--- a/lib/pages/live_room/view.dart
+++ b/lib/pages/live_room/view.dart
@@ -129,6 +129,10 @@ class _LiveRoomPageState extends State<LiveRoomPage>
 
   @override
   Future<void> didPopNext() async {
+    // 从覆盖页面返回直播页时重新进入沉浸模式：移除安全边距或仍处于全屏时
+    if (plPlayerController.removeSafeArea || plPlayerController.isFullScreen.value) {
+      hideSystemBar();
+    }
     addObserverMobile(this);
     HarmonyChannel.holdDecorDark(this);
     if (!plPlayerController.isLive) {

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -455,6 +455,12 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
       return;
     }
 
+    // 从覆盖页面返回播放页时重新进入沉浸模式：移除安全边距（页面级沉浸）
+    // 或仍处于全屏（全屏沉浸）时恢复隐藏
+    if (videoDetailController.removeSafeArea || isFullScreen) {
+      hideSystemBar();
+    }
+
     HarmonyChannel.holdDecorDark(this);
     WidgetsBinding.instance.addObserver(this);
 

--- a/lib/plugin/pl_player/utils/fullscreen.dart
+++ b/lib/plugin/pl_player/utils/fullscreen.dart
@@ -158,6 +158,15 @@ Future<void>? showSystemBar(String reason) {
   );
 }
 
+/// 供路由观察器在页面回到栈底时调用：若系统栏当前被隐藏则恢复。
+/// 与原生顶栏的显隐同频，避免「顶栏已先出现、状态栏要等转场结束才恢复」
+/// 导致页面布局在转场结束后下移（issue #151）。
+void restoreSystemBarIfHidden() {
+  if (!_showSystemBar) {
+    showSystemBar('observer_sync');
+  }
+}
+
 Future<void> toggleSystemBar() {
   _showSystemBar = !_showSystemBar;
   return SystemChrome.setEnabledSystemUIMode(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,6 +82,7 @@ dependencies:
   # 浏览器
   # webview_flutter: ^4.10.0
   flutter_inappwebview: ^6.1.5
+  flutter_inappwebview_windows: ^0.6.0
   # 解决sliver滑动不同步
   # extended_nested_scroll_view: ^6.2.1
   extended_nested_scroll_view:


### PR DESCRIPTION
## 修复内容

开启「播放页移除安全边距」后，系统状态栏的显隐存在两个问题：

1. **退出播放页回首页时状态栏跳动（#151）**：状态栏在页面转场结束后才恢复，首页原生顶栏先出现、状态栏晚一拍弹出，导致界面整体下移。
2. **播放页压栈进入普通页面（如 UP 主主页）后状态栏丢失**：新页面继承播放页的沉浸状态，状态栏消失，需下滑唤出且悬浮覆盖在界面上；嵌套场景（播放页 → UP 主主页 → 再进播放页 → 返回）同样受影响。

## 改动方案

- 在路由观察器 `ShellBarsObserver` 中，让系统状态栏跟随「最上层页面」：
  - 最上层是播放页（/videoV、/liveRoom）→ 保持沉浸
  - 最上层是普通整页 → 立即恢复状态栏（覆盖任意嵌套深度）
  - 图片查看器（HeroDialogRoute）→ 不干预（自带状态栏逻辑）
- 播放页返回时重新进入沉浸（含全屏场景）。

涉及文件：
- lib/harmony_adapt/shell_bars_observer.dart
- lib/plugin/pl_player/utils/fullscreen.dart
- lib/pages/video/view.dart
- lib/pages/live_room/view.dart

## 额外构建补丁（第二个 commit）

`flutter build hap` 当前会因 flutter_inappwebview 声明了 Windows 默认插件但未声明对应依赖而失败，补上 `flutter_inappwebview_windows` 依赖以恢复构建。

## 验证

- 真机（HarmonyOS API 24+）验证 #151 场景与压栈场景均正常。
- flutter analyze 通过；release 构建通过。