### PR TITLE
fix: 修复鸿蒙小窗内全屏自动退出与竖屏全屏可滚动压缩问题

### DIFF
--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -652,7 +652,8 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
             isManualFS: false,
           );
         });
-      } else if (isPortrait &&
+      } else if (aspectIsOrientation &&
+          isPortrait &&
           isFullScreen &&
           // 鸿蒙手动进全屏（auto/ratio 等）同样跟随传感器转屏，
           // 手机转回竖屏时窗口会跟着转回，需要自动退出全屏；
@@ -730,6 +731,11 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
             scrollBehavior: NoOverscrollBehavior(),
             key: videoDetailController.scrollKey,
             controller: videoDetailController.scrollCtr,
+            // 全屏时禁止页面滚动：竖屏全屏只是把视频头撑满全屏，若不锁滚动，
+            // 底部上滑会把头部视频压缩、把详情内容从底部带出来。
+            physics: isFullScreen
+                ? const NeverScrollableScrollPhysics()
+                : null,
             onlyOneScrollInBody: true,
             pinnedHeaderSliverHeightBuilder: () {
               double pinnedHeight = isFullScreen || !isPortrait
@@ -766,7 +772,9 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
                   : videoDetailController.videoHeight;
               return [
                 VideoHeader(
-                  minExtent: kToolbarHeight,
+                  // 全屏时头部最小高度与满屏高度一致，即使保留滚动偏移
+                  // 也不能把视频压缩，详情内容被挡在屏幕外。
+                  minExtent: isFullScreen ? height : kToolbarHeight,
                   maxExtent: height,
                   minVideoHeight: videoDetailController.minVideoHeight,
                   onScrollRatioChanged: videoDetailController.scrollRatio.call,


### PR DESCRIPTION
## 改动内容

- 修复鸿蒙小窗（悬浮窗/全景多窗）内全屏播放失败：小窗内点全屏不再“先缩小又弹回详情页”，全屏播放时划成小窗也不再跳回详情页
  - 自动退出全屏的启发式不再按小窗窗口宽高比触发（小窗宽高比不代表设备方向）
- 修复竖屏视频全屏时可滚动压缩问题：全屏时锁定详情页滚动，并将视频头部最小高度锁为满屏高度
  - 底部上滑不再把视频压缩、露出底部详情内容；进入全屏前已有滚动偏移时同样保持满屏

## 验证

- 小窗内点全屏 / 全屏时划成小窗：真机验证通过
- 竖屏全屏滚动锁定：真机验证通过
- 未提交 pubspec.lock