### PR TITLE
fix: 修复听视频后台单曲循环被系统冻结，并同步循环模式到播控中心

### DIFF
--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -88,6 +88,20 @@ class AudioController extends GetxController
   late double speed = 1.0;
 
   late final Rx<PlayRepeat> playMode = Pref.audioPlayMode.obs;
+  StreamSubscription<PlayRepeat>? _playModeSub;
+  Future<void> Function(PlayRepeat)? _savedOnRepeatModeChanged;
+
+  /// 自动续播抑制窗口：单曲/列表循环播完瞬间不上报暂停/完成，
+  /// 避免鸿蒙后台连续任务被停（第二遍播几秒后被系统冻结/杀掉）。
+  DateTime? _suppressPauseUntil;
+
+  bool get _suppressPauseReport =>
+      _suppressPauseUntil != null &&
+      DateTime.now().isBefore(_suppressPauseUntil!);
+
+  bool get _autoContinue =>
+      playMode.value == PlayRepeat.singleCycle ||
+      playMode.value == PlayRepeat.listCycle;
 
   @override
   late final isLogin = Accounts.main.isLogin;
@@ -177,6 +191,16 @@ class AudioController extends GetxController
       _savedOnSkipToNext = handler.onSkipToNext;
       handler.onSkipToPrevious = () async => playPrev();
       handler.onSkipToNext = () async => playNext();
+      // 循环模式：应用→播控中心（实况窗图标），播控中心→应用（点按钮切换）
+      _savedOnRepeatModeChanged = handler.onRepeatModeChanged;
+      handler.onRepeatModeChanged = (repeat) async {
+        playMode.value = repeat;
+        GStorage.setting.put(SettingBoxKey.audioPlayMode, repeat.index);
+      };
+      handler.updateRepeatMode(playMode.value);
+      _playModeSub = playMode.listen(
+        (m) => videoPlayerServiceHandler?.updateRepeatMode(m),
+      );
     }
 
     animController = AnimationController(
@@ -375,16 +399,32 @@ class AudioController extends GetxController
           animController.reverse();
           playerStatus = PlayerStatus.paused;
         }
-        videoPlayerServiceHandler?.onStatusChange(playerStatus, false, false);
+        // 自然播完且会自动续播时，不向播控中心上报暂停（保持播放态，
+        // 避免后台连续任务被停）；重播窗口内的事件同样跳过
+        final naturalEnd =
+            !playing &&
+            _autoContinue &&
+            duration.value > 2 &&
+            position.value >= duration.value - 2;
+        if (!naturalEnd && !_suppressPauseReport) {
+          videoPlayerServiceHandler?.onStatusChange(playerStatus, false, false);
+        }
       }),
       stream.completed.listen((completed) {
         _videoDetailController?.playedTime = player!.state.duration;
-        videoPlayerServiceHandler?.onStatusChange(
-          PlayerStatus.completed,
-          false,
-          false,
-        );
         if (completed) {
+          if (_autoContinue) {
+            // 自动续播：进入抑制窗口，不向播控中心上报完成/停止
+            _suppressPauseUntil = DateTime.now().add(
+              const Duration(seconds: 6),
+            );
+          } else {
+            videoPlayerServiceHandler?.onStatusChange(
+              PlayerStatus.completed,
+              false,
+              false,
+            );
+          }
           if (shutdownTimerService.isWaiting) {
             shutdownTimerService.handleWaiting();
           } else {
@@ -780,7 +820,10 @@ class AudioController extends GetxController
       handler.onSeek = null;
       handler.onSkipToPrevious = _savedOnSkipToPrevious;
       handler.onSkipToNext = _savedOnSkipToNext;
+      handler.onRepeatModeChanged = _savedOnRepeatModeChanged;
     }
+    _playModeSub?.cancel();
+    _playModeSub = null;
     _subscriptions?.forEach((e) => e.cancel());
     _subscriptions?.clear();
     _subscriptions = null;

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -128,6 +128,23 @@ class PlPlayerController with BlockConfigMixin {
   final RxBool isFullScreen = false.obs;
   bool isLive = false;
 
+  /// 自动重播抑制窗口：从单曲循环重播开始到播放稳定前，抑制所有
+  /// playing=false/buffering(completed) 上报，防止鸿蒙后台连续任务被停。
+  DateTime? _suppressPauseUntil;
+
+  bool get _suppressPauseReport =>
+      _suppressPauseUntil != null &&
+      DateTime.now().isBefore(_suppressPauseUntil!);
+
+  /// 自然播放结束且单曲循环会立即重播：播控中心保持播放态、不停后台连续任务，
+  /// 避免任务停掉后在后台无法重新拉起（表现为第二遍播几秒后被挂起）。
+  bool get _naturalEndWillReplay =>
+      !_pauseRequestedByApp &&
+      !isLive &&
+      playRepeat == PlayRepeat.singleCycle &&
+      durationInMilliseconds > 2000 &&
+      positionInMilliseconds >= durationInMilliseconds - 2000;
+
   bool _isVertical = false;
 
   final Rx<VideoFitType> videoFit = Rx(.contain);
@@ -1077,11 +1094,13 @@ class PlPlayerController with BlockConfigMixin {
           Floating().updatePipControlStatus(playing: playing);
         }
 
-        videoPlayerServiceHandler?.onStatusChange(
-          playerStatus.value,
-          isBuffering.value,
-          isLive,
-        );
+        if (playing || (!_suppressPauseReport && !_naturalEndWillReplay)) {
+          videoPlayerServiceHandler?.onStatusChange(
+            playerStatus.value,
+            isBuffering.value,
+            isLive,
+          );
+        }
 
         for (final element in _statusListeners) {
           element(playing ? .playing : .paused);
@@ -1130,11 +1149,13 @@ class PlPlayerController with BlockConfigMixin {
       }),
       stream.buffering.listen((bool buffering) {
         isBuffering.value = buffering;
-        videoPlayerServiceHandler?.onStatusChange(
-          playerStatus.value,
-          buffering,
-          isLive,
-        );
+        if (!_suppressPauseReport && !_naturalEndWillReplay) {
+          videoPlayerServiceHandler?.onStatusChange(
+            playerStatus.value,
+            buffering,
+            isLive,
+          );
+        }
       }),
       if (kDebugMode)
         stream.log.listen(((PlayerLog log) {
@@ -1250,7 +1271,20 @@ class PlPlayerController with BlockConfigMixin {
           _stallTicks = 0;
           _stallLastPosition = null;
           _audioInterrupted = true;
+          // 听视频后台模式：看门狗误判（循环重播瞬间音频输出被系统挂起）时
+          // 限次自动恢复，避免第二遍播几秒后永远停住
+          final shouldAutoResume =
+              OS.isHarmony &&
+              continuePlayInBackground.value &&
+              _bgAutoResumeAllowed();
           pause(isInterrupt: true);
+          if (shouldAutoResume) {
+            Future<void>.delayed(const Duration(milliseconds: 800), () {
+              if (continuePlayInBackground.value) {
+                play();
+              }
+            });
+          }
         }
       } else {
         _stallTicks = 0;
@@ -1341,6 +1375,9 @@ class PlPlayerController with BlockConfigMixin {
     controls = !hideControls;
     // repeat为true，将从头播放
     if (repeat) {
+      // 进入自动重播抑制窗口：6 秒内旧 playing=false / buffering(completed)
+      // 一律不向播控中心上报，防止后台连续任务被停
+      _suppressPauseUntil = DateTime.now().add(const Duration(seconds: 6));
       // await seekTo(Duration.zero);
       await seekTo(Duration.zero, isSeek: false);
     }
@@ -1365,6 +1402,15 @@ class PlPlayerController with BlockConfigMixin {
     audioSessionHandler?.setActive(true);
 
     playerStatus.value = PlayerStatus.playing;
+    if (_suppressPauseReport) {
+      // 立即把播放中状态推给播控中心，重启后台连续任务，
+      // 防止晚到的 playing=false/buffering(completed) 把它停掉
+      videoPlayerServiceHandler?.setPlaybackState(
+        PlayerStatus.playing,
+        isBuffering.value,
+        isLive,
+      );
+    }
     // screenManager.setOverlays(false);
   }
 
@@ -1375,6 +1421,8 @@ class PlPlayerController with BlockConfigMixin {
   bool _pauseRequestedByApp = false;
   int _pipAutoResumeCount = 0;
   DateTime? _pipAutoResumeWindowStart;
+  int _bgAutoResumeCount = 0;
+  DateTime? _bgAutoResumeWindowStart;
 
   /// 生命周期回调的补偿入口：处于画中画且播放被系统静默暂停（而非应用
   /// 主动暂停）时自动续播。覆盖"系统暂停发生在 isPipMode 置位之前"的
@@ -1403,8 +1451,21 @@ class PlPlayerController with BlockConfigMixin {
     return ++_pipAutoResumeCount <= 3;
   }
 
+  /// 限制听视频后台看门狗自动恢复的频率，防止与系统强制暂停陷入拉锯。
+  bool _bgAutoResumeAllowed() {
+    final now = DateTime.now();
+    if (_bgAutoResumeWindowStart == null ||
+        now.difference(_bgAutoResumeWindowStart!) >
+            const Duration(seconds: 10)) {
+      _bgAutoResumeWindowStart = now;
+      _bgAutoResumeCount = 0;
+    }
+    return ++_bgAutoResumeCount <= 3;
+  }
+
   Future<void> pause({bool notify = true, bool isInterrupt = false}) async {
     _pauseRequestedByApp = true;
+    _suppressPauseUntil = null;
     await _videoPlayerController?.pause();
     playerStatus.value = PlayerStatus.paused;
 
@@ -1855,6 +1916,12 @@ class PlPlayerController with BlockConfigMixin {
 
   void setPlayRepeat(PlayRepeat type) {
     playRepeat = type;
+    final handler = videoPlayerServiceHandler;
+    handler?.updateRepeatMode(type);
+    // 视频页循环模式也支持从播控中心/实况窗切换
+    handler?.onRepeatModeChanged = (repeat) async {
+      setPlayRepeat(repeat);
+    };
     if (!tempPlayerConf) video.put(VideoBoxKey.playRepeat, type.index);
   }
 

--- a/lib/services/audio_handler.dart
+++ b/lib/services/audio_handler.dart
@@ -10,6 +10,7 @@ import 'package:PiliPlus/models_new/pgc/pgc_info_model/episode.dart';
 import 'package:PiliPlus/models_new/video/video_detail/data.dart';
 import 'package:PiliPlus/models_new/video/video_detail/page.dart';
 import 'package:PiliPlus/plugin/pl_player/controller.dart';
+import 'package:PiliPlus/plugin/pl_player/models/play_repeat.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_status.dart';
 import 'package:PiliPlus/utils/android/bindings.g.dart';
 import 'package:PiliPlus/utils/cache_manager.dart';
@@ -46,6 +47,12 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
 
   static final List<MediaItem> _item = [];
   bool enableBackgroundPlay;
+
+  /// 当前循环模式（同步给系统播控中心/实况窗显示与切换）
+  AudioServiceRepeatMode repeatMode = AudioServiceRepeatMode.none;
+
+  /// 实况窗/播控中心切换循环模式时回调给当前播放页
+  Future<void> Function(PlayRepeat repeat)? onRepeatModeChanged;
 
   Future<void>? Function()? onPlay;
   Future<void>? Function()? onPause;
@@ -160,6 +167,7 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
               action: MediaAction.fastForward,
             ),
         ],
+        repeatMode: repeatMode,
         playing: playing,
         systemActions: const {
           MediaAction.seek,
@@ -203,6 +211,30 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
     unawaited(
       _handleVideoDetailChange(data, cid, herotag, artist: artist, cover: cover),
     );
+  }
+
+  /// 应用侧循环模式变化时同步给播控中心
+  void updateRepeatMode(PlayRepeat repeat) {
+    final mode = switch (repeat) {
+      PlayRepeat.singleCycle => AudioServiceRepeatMode.one,
+      PlayRepeat.listCycle => AudioServiceRepeatMode.all,
+      _ => AudioServiceRepeatMode.none,
+    };
+    if (mode == repeatMode) return;
+    repeatMode = mode;
+    playbackState.add(playbackState.value.copyWith(repeatMode: mode));
+  }
+
+  @override
+  Future<void> setRepeatMode(AudioServiceRepeatMode repeatMode) async {
+    this.repeatMode = repeatMode;
+    playbackState.add(playbackState.value.copyWith(repeatMode: repeatMode));
+    final repeat = switch (repeatMode) {
+      AudioServiceRepeatMode.one => PlayRepeat.singleCycle,
+      AudioServiceRepeatMode.all => PlayRepeat.listCycle,
+      _ => PlayRepeat.listOrder,
+    };
+    await onRepeatModeChanged?.call(repeat);
   }
 
   /// 优先复用项目图片缓存（cached_network_image_ce）中的封面文件并返回


### PR DESCRIPTION
## 问题

听视频（音频页）后台播放 + 单曲循环时，第二遍播几秒后被系统冻结/杀掉：

- 播完瞬间应用向播控中心上报“暂停/完成”，鸿蒙插件会随之停止后台连续任务
- 重播开始时 media_kit 会再发一次 completed=false 事件，被误报为完成状态，把刚重启的后台任务又停掉
- 系统随后冻结应用并杀掉（日志：AUDIO_RENDERER cannot be used after being frozen）

## 改动

- 听视频页播完不再向播控中心上报暂停/完成；自动续播（单曲/列表循环）期间进入 6 秒抑制窗口，保持播放态，后台连续任务不被停
- 修复 completed 事件（含重播时的 completed=false）被误报为完成状态的问题
- 视频页单曲循环重播同步加状态上报保护
- 循环模式同步到播控中心/实况窗（单曲循环/列表循环图标与 app 一致），并支持从实况窗切换循环模式（会同步回 app 并持久化）

## 验证

- 真机验证：听视频 + 单曲循环后台循环播放正常，不再被冻结
- 实况窗循环图标与 app 一致，可在实况窗切换循环模式
- 未提交 pubspec.lock