### PR TITLE
fix: 竖屏全屏顶部控件避让摄像头挖孔

### DIFF
--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -1450,6 +1450,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
                 videoDetailCtr: videoDetailController,
                 heroTag: heroTag,
               ),
+              topInset: _fixedTopInset,
               danmuWidget: isPipMode && pipNoDanmaku
                   ? null
                   : Obx(

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -101,6 +101,7 @@ class PLVideoPlayer extends StatefulWidget {
     this.danmuWidget,
     this.showEpisodes,
     this.showViewPoints,
+    this.topInset,
     this.fill = Colors.black,
     this.alignment = Alignment.center,
     super.key,
@@ -124,6 +125,11 @@ class PLVideoPlayer extends StatefulWidget {
   ])?
   showEpisodes;
   final VoidCallback? showViewPoints;
+
+  /// 竖屏全屏时顶部控件的固定避让高度（进全屏前捕获的状态栏/挖孔高度），
+  /// null 表示不避让
+  final double? topInset;
+
   final Color fill;
   final Alignment alignment;
 
@@ -1695,6 +1701,7 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
                     controller: _animationController,
                     isFullScreen: isFullScreen,
                     removeSafeArea: plPlayerController.removeSafeArea,
+                    topInset: widget.topInset,
                     child: plPlayerController.isDesktopPip
                         ? GestureDetector(
                             behavior: HitTestBehavior.translucent,

--- a/lib/plugin/pl_player/widgets/app_bar_ani.dart
+++ b/lib/plugin/pl_player/widgets/app_bar_ani.dart
@@ -9,6 +9,7 @@ class AppBarAni extends StatelessWidget {
     required this.isTop,
     required this.isFullScreen,
     required this.removeSafeArea,
+    this.topInset,
   });
 
   final Widget child;
@@ -16,6 +17,9 @@ class AppBarAni extends StatelessWidget {
   final bool isTop;
   final bool isFullScreen;
   final bool removeSafeArea;
+
+  /// 竖屏全屏时顶部控件的固定避让高度（进全屏前捕获的状态栏/挖孔高度）
+  final double? topInset;
 
   static final _topPos = Tween<Offset>(
     begin: const Offset(0.0, -1.0),
@@ -49,19 +53,32 @@ class AppBarAni extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Widget result = child;
+    if (!removeSafeArea) {
+      result = ViewSafeArea(
+        left: isFullScreen,
+        right: isFullScreen,
+        child: result,
+      );
+      // 竖屏全屏时用进全屏前捕获的固定高度避让挖孔/状态栏，
+      // 不依赖全屏下已归零的 MediaQuery padding
+      if (isTop &&
+          isFullScreen &&
+          MediaQuery.sizeOf(context).height >= MediaQuery.sizeOf(context).width &&
+          (topInset ?? 0) > 0) {
+        result = Padding(
+          padding: EdgeInsets.only(top: topInset!),
+          child: result,
+        );
+      }
+    }
     return SlideTransition(
       position: controller.drive(isTop ? _topPos : _bottomPos),
       child: DecoratedBox(
         decoration: BoxDecoration(
           gradient: isTop ? _topDecoration : _bottomDecoration,
         ),
-        child: removeSafeArea
-            ? child
-            : ViewSafeArea(
-                left: isFullScreen,
-                right: isFullScreen,
-                child: child,
-              ),
+        child: result,
       ),
     );
   }


### PR DESCRIPTION
## 问题

竖屏视频竖屏全屏播放时，播放器顶部的返回/标题等控件会被前置摄像头挖孔遮挡一小部分。

原因：全屏顶部控件（AppBarAni）只开了左右安全区，顶部安全区从未启用；且全屏时状态栏隐藏后 MediaQuery 的顶部 padding 可能归零，直接读实时值不可靠。

## 改动

- 视频页在进全屏前捕获状态栏/挖孔高度（复用已有的 `_fixedTopInset`），传入播放器
- 播放器顶部控件在**竖屏全屏**时按该固定值下移避让，不依赖全屏下已归零的 MediaQuery padding
- 仅竖屏全屏生效；横屏全屏、非全屏、开启“移除安全边距”的用户不受影响
- 只移动控件，视频画面仍全屏铺满

## 验证

- 真机验证通过：竖屏全屏顶部控件不再被挖孔遮挡
- 未提交 pubspec.lock