### PR TITLE
fix(ui): 修复视频页 Hero 动画优化引入的旋转与全屏异常

### DIFF
--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -166,11 +166,23 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
   @override
   void initState() {
     super.initState();
+    // 方向/布局状态必须首帧同步可用：旋转与全屏状态机在 build 里依赖
+    // isPortrait、maxWidth/maxHeight 与 _unlockOrientation，它们必须总是
+    // build 前的当前值。控制器构造本身轻量（onInit 只初始化字段，网络
+    // 请求在 videoSourceInit 中执行），同步创建即可让 _unlockOrientation
+    // 与 didChangeDependencies 立即以正确状态生效。
+    videoDetailController = Get.put(VideoDetailController(), tag: heroTag);
+    if (videoDetailController.removeSafeArea) {
+      hideSystemBar();
+    }
+    _unlockOrientation();
+
+    // 其余初始化延迟到 Hero 过渡结束后：查询播放地址、初始化播放器、创建
+    // 分页控制器、注册生命周期观察者都是较重的工作，放首帧会卡 Hero 动画。
     Future.delayed(
       _waitingHero ? _heroDuration : Duration.zero,
       () {
         PlPlayerController.setPlayCallBack(playCallBack);
-        videoDetailController = Get.put(VideoDetailController(), tag: heroTag);
         // 页面顶部是黑色播放器：自由多窗的装饰栏按钮切浅色风格，否则浅色
         // 模式下深色按钮不可见
         HarmonyChannel.holdDecorDark(this);
@@ -183,12 +195,6 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
             if (mounted) setState(() {});
           },
         );
-
-        if (videoDetailController.removeSafeArea) {
-          hideSystemBar();
-        }
-
-        _unlockOrientation();
 
         if (videoDetailController.showReply) {
           _videoReplyController = Get.put(
@@ -541,44 +547,45 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    Future.delayed(_waitingHero ? _heroDuration : Duration.zero, () {
-      if (!mounted) return;
-      if (videoDetailController.removeSafeArea) {
-        padding = .zero;
-      } else {
-        padding = MediaQuery.viewPaddingOf(context);
-      }
-      // 顶部间距固定为首次捕获的状态栏高度：状态栏显隐不再改变页面布局，
-      // 避免旋转退出全屏时状态栏在动画末尾显现导致画面下移。
-      if (padding.top > 0) {
-        _fixedTopInset ??= padding.top;
-      }
+    // 布局/方向状态必须在这里同步计算：旋转（MediaQuery 变化）时本方法先于
+    // build 执行，保证 build 读到的 isPortrait/maxWidth/maxHeight 永远是当前值。
+    // 若像 Hero 优化那样延迟到 Future.delayed 里再算，旋转后 build 会读到过期
+    // 的 isPortrait，childWhenDisabled 的自动进/退全屏逻辑就会在错误方向上触发
+    // （例如点全屏后误判窗口已回竖屏，调度 _restorePageOrientation 又转回竖屏）。
+    if (videoDetailController.removeSafeArea) {
+      padding = .zero;
+    } else {
+      padding = MediaQuery.viewPaddingOf(context);
+    }
+    // 顶部间距固定为首次捕获的状态栏高度：状态栏显隐不再改变页面布局，
+    // 避免旋转退出全屏时状态栏在动画末尾显现导致画面下移。
+    if (padding.top > 0) {
+      _fixedTopInset ??= padding.top;
+    }
 
-      final size = MediaQuery.sizeOf(context);
-      maxWidth = size.width;
-      maxHeight = size.height;
-      isWindowMode = MaxScreenSize.isWindowMode(
-        width: maxWidth * videoDetailController.uiScale,
-        height: maxHeight * videoDetailController.uiScale,
-      );
-      videoDetailController.plPlayerController.screenRatio =
-          maxHeight / maxWidth;
+    final size = MediaQuery.sizeOf(context);
+    maxWidth = size.width;
+    maxHeight = size.height;
+    isWindowMode = MaxScreenSize.isWindowMode(
+      width: maxWidth * videoDetailController.uiScale,
+      height: maxHeight * videoDetailController.uiScale,
+    );
+    videoDetailController.plPlayerController.screenRatio = maxHeight / maxWidth;
 
-      final shortestSide = size.shortestSide;
-      final minVideoHeight = shortestSide / Style.aspectRatio16x9;
-      final maxVideoHeight = max(size.longestSide * 0.65, shortestSide);
-      videoDetailController
-        ..isPortrait = isPortrait = maxHeight >= maxWidth
-        ..minVideoHeight = minVideoHeight
-        ..maxVideoHeight = maxVideoHeight
-        ..videoHeight = videoDetailController.isVertical.value
-            ? maxVideoHeight
-            : minVideoHeight;
+    final shortestSide = size.shortestSide;
+    final minVideoHeight = shortestSide / Style.aspectRatio16x9;
+    final maxVideoHeight = max(size.longestSide * 0.65, shortestSide);
+    videoDetailController
+      ..isPortrait = isPortrait = maxHeight >= maxWidth
+      ..minVideoHeight = minVideoHeight
+      ..maxVideoHeight = maxVideoHeight
+      ..videoHeight = videoDetailController.isVertical.value
+          ? maxVideoHeight
+          : minVideoHeight;
 
-      themeData = videoDetailController.plPlayerController.darkVideoPage
-          ? ThemeUtils.darkTheme
-          : Theme.of(context);
-    });
+    themeData = videoDetailController.plPlayerController.darkVideoPage
+        ? ThemeUtils.darkTheme
+        : Theme.of(context);
   }
 
   /// 当前放开着方向的播放页数量。视频页可以叠栈（视频里再点视频），用计数避免

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
 # update when release
-version: 2.1.0+5666
+version: 2.1.0+5667
 
 environment:
   sdk: ">=3.11.1"


### PR DESCRIPTION
## 问题描述
4111c9205（refactor(ui): 优化视频页Hero 动画卡顿）引入后出现两个回归：
1. 进入视频页后旋转行为异常：横屏时界面表现如同开启了「横屏适配」。
2. 全屏按钮偶发「转了又转回去」：点击全屏后出现旋转动画，但随即被转回竖屏并退出全屏。

## 原因
该提交为支持 Hero 封面过渡，把 _VideoDetailPageVState 的初始化整体延后到 Future.delayed（启用 Hero 时延迟 300ms），didChangeDependencies 的布局计算也改为延迟执行，期间 build 渲染空壳。这破坏了页面旋转/全屏状态机依赖的两个前提：
- isPortrait 不再总是 build 时的当前值：旋转后布局计算延迟到下一帧才落地，childWhenDisabled 的自动退全屏分支会在「窗口已横屏、isPortrait 仍为竖屏」的帧被误触发，进而调用 _restorePageOrientation() 把窗口硬掰回竖屏——即症状 2。
- _unlockOrientation() 延迟 300ms：其 _orientationHolders 静态计数与页面栈生命周期（dispose/didPushNext 中同步的 _lockOrientation）错位，关闭「横屏适配」时的方向锁在叠栈/进出页面时漏锁或锁错时机——即症状 1。

## 修复方案
在保留 Hero 动画优化（重活仍延迟、过渡期渲染空壳）的前提下，将方向/布局状态恢复到首帧同步计算：
1. initState：VideoDetailController 创建、hideSystemBar、_unlockOrientation() 提前到同步执行。控制器构造本身轻量（onInit 仅初始化字段），网络请求与播放器初始化仍在延迟回调中，不影响 Hero 过渡流畅度。
2. didChangeDependencies：移除 Future.delayed 包裹，恢复同步计算 isPortrait/maxWidth/maxHeight，保证每次 build 读到的是当前方向。

## 影响范围
仅 lib/pages/video/view.dart。