### PR TITLE
fix: 竖屏全屏弹幕与播控组件统一避让摄像头挖孔

### DIFF
--- a/lib/pages/danmaku/view.dart
+++ b/lib/pages/danmaku/view.dart
@@ -6,6 +6,7 @@ import 'package:PiliPlus/pages/danmaku/danmaku_model.dart';
 import 'package:PiliPlus/plugin/pl_player/controller.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_status.dart';
 import 'package:PiliPlus/plugin/pl_player/utils/danmaku_options.dart';
+import 'package:PiliPlus/plugin/pl_player/utils/fullscreen.dart';
 import 'package:PiliPlus/utils/danmaku_utils.dart';
 import 'package:canvas_danmaku/canvas_danmaku.dart';
 import 'package:flutter/material.dart';
@@ -19,6 +20,7 @@ class PlDanmaku extends StatefulWidget {
   final bool isFullScreen;
   final bool isFileSource;
   final Size size;
+  final double? topInset;
 
   const PlDanmaku({
     super.key,
@@ -28,6 +30,7 @@ class PlDanmaku extends StatefulWidget {
     required this.isFullScreen,
     required this.isFileSource,
     required this.size,
+    this.topInset,
   });
 
   @override
@@ -173,6 +176,17 @@ class _PlDanmakuState extends State<PlDanmaku> {
       notFullscreen: widget.notFullscreen,
       speed: playerController.playbackSpeed,
     );
+    // 竖屏全屏时与顶部控件共用同一套顶部避让，并把可视高度同步减去，
+    // 让弹幕轨道按缩小后的区域正确排布
+    final inset = portraitFullscreenTopInset(
+      isFullScreen: widget.isFullScreen,
+      isPortrait: widget.size.height >= widget.size.width,
+      removeSafeArea: playerController.removeSafeArea,
+      topInset: widget.topInset,
+    );
+    final danmakuSize = inset == null
+        ? widget.size
+        : Size(widget.size.width, widget.size.height - inset);
     return Obx(
       () => AnimatedOpacity(
         opacity: playerController.enableShowDanmaku.value
@@ -184,7 +198,7 @@ class _PlDanmakuState extends State<PlDanmaku> {
             playerController.danmakuController = _controller = e;
           },
           option: option,
-          size: widget.size,
+          size: danmakuSize,
         ),
       ),
     );

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -1418,6 +1418,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
                         isFullScreen: plPlayerController!.isFullScreen.value,
                         isFileSource: videoDetailController.isFileSource,
                         size: Size(width, height),
+                        topInset: _fixedTopInset,
                       ),
                     ),
               showEpisodes: showEpisodes,

--- a/lib/plugin/pl_player/utils/fullscreen.dart
+++ b/lib/plugin/pl_player/utils/fullscreen.dart
@@ -12,6 +12,20 @@ import 'package:os_type/os_type.dart';
 /// 才“长高”导致整体下移一跳。
 const Duration kSystemBarSettleDelay = Duration(milliseconds: 120);
 
+/// 竖屏全屏时的顶部避让高度：仅在全屏 + 竖屏 + 未移除安全边距时返回
+/// [topInset]（进全屏前捕获的状态栏/挖孔高度），否则返回 null（不避让）。
+/// 播控顶部组件与弹幕共用这一套判断，保证两处行为一致。
+double? portraitFullscreenTopInset({
+  required bool isFullScreen,
+  required bool isPortrait,
+  required bool removeSafeArea,
+  required double? topInset,
+}) {
+  if (!isFullScreen || !isPortrait || removeSafeArea) return null;
+  final inset = topInset ?? 0;
+  return inset > 0 ? inset : null;
+}
+
 bool _isDesktopFullScreen = false;
 
 @pragma('vm:notify-debugger-on-exception')

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -43,6 +43,8 @@ import 'package:PiliPlus/plugin/pl_player/models/fullscreen_mode.dart';
 import 'package:PiliPlus/plugin/pl_player/models/gesture_type.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_status.dart';
 import 'package:PiliPlus/plugin/pl_player/models/video_fit_type.dart';
+import 'package:PiliPlus/plugin/pl_player/utils/fullscreen.dart';
+import 'package:PiliPlus/plugin/pl_player/widgets/top_inset_padding.dart';
 import 'package:PiliPlus/plugin/pl_player/widgets/app_bar_ani.dart';
 import 'package:PiliPlus/plugin/pl_player/widgets/backward_seek.dart';
 import 'package:PiliPlus/plugin/pl_player/widgets/bottom_control.dart';
@@ -1411,7 +1413,18 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
         _videoWidget,
 
         if (widget.danmuWidget case final danmaku?)
-          Positioned.fill(top: 4, child: danmaku),
+          Positioned.fill(
+            top: 4,
+            child: TopInsetPadding(
+              inset: portraitFullscreenTopInset(
+                isFullScreen: isFullScreen,
+                isPortrait: maxHeight >= maxWidth,
+                removeSafeArea: plPlayerController.removeSafeArea,
+                topInset: widget.topInset,
+              ),
+              child: danmaku,
+            ),
+          ),
 
         if (!isLive)
           // 鸿蒙 media_kit fork 的 SubtitleView 没有上游 fork 的

--- a/lib/plugin/pl_player/widgets/app_bar_ani.dart
+++ b/lib/plugin/pl_player/widgets/app_bar_ani.dart
@@ -1,4 +1,6 @@
 import 'package:PiliPlus/common/widgets/view_safe_area.dart';
+import 'package:PiliPlus/plugin/pl_player/utils/fullscreen.dart';
+import 'package:PiliPlus/plugin/pl_player/widgets/top_inset_padding.dart';
 import 'package:flutter/material.dart';
 
 class AppBarAni extends StatelessWidget {
@@ -53,6 +55,13 @@ class AppBarAni extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final top = portraitFullscreenTopInset(
+      isFullScreen: isFullScreen,
+      isPortrait:
+          MediaQuery.sizeOf(context).height >= MediaQuery.sizeOf(context).width,
+      removeSafeArea: removeSafeArea,
+      topInset: topInset,
+    );
     Widget result = child;
     if (!removeSafeArea) {
       result = ViewSafeArea(
@@ -60,17 +69,9 @@ class AppBarAni extends StatelessWidget {
         right: isFullScreen,
         child: result,
       );
-      // 竖屏全屏时用进全屏前捕获的固定高度避让挖孔/状态栏，
-      // 不依赖全屏下已归零的 MediaQuery padding
-      if (isTop &&
-          isFullScreen &&
-          MediaQuery.sizeOf(context).height >= MediaQuery.sizeOf(context).width &&
-          (topInset ?? 0) > 0) {
-        result = Padding(
-          padding: EdgeInsets.only(top: topInset!),
-          child: result,
-        );
-      }
+      // 与弹幕共用同一套顶部避让（TopInsetPadding），
+      // 仅顶部栏需要，底部栏不避让
+      result = TopInsetPadding(inset: isTop ? top : null, child: result);
     }
     return SlideTransition(
       position: controller.drive(isTop ? _topPos : _bottomPos),

--- a/lib/plugin/pl_player/widgets/top_inset_padding.dart
+++ b/lib/plugin/pl_player/widgets/top_inset_padding.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+/// 顶部避让内边距：竖屏全屏时弹幕、播控顶部组件共用的统一 Padding。
+/// [inset] 为 null 或 <= 0 时不加内边距，原样返回 child。
+class TopInsetPadding extends StatelessWidget {
+  const TopInsetPadding({super.key, required this.inset, required this.child});
+
+  final double? inset;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final top = inset ?? 0;
+    return top > 0
+        ? Padding(padding: EdgeInsets.only(top: top), child: child)
+        : child;
+  }
+}


### PR DESCRIPTION
## 问题 

竖屏全屏播放时，顶部播控组件和弹幕会被摄像头挖孔/状态栏遮挡 

## 改动内容

- `fullscreen.dart`：新增 `portraitFullscreenTopInset()`，统一判断“全屏 + 竖屏 + 未移除安全边距 + topInset>0”，播控顶部组件与弹幕共用，保证两处行为一致。
- 新增 `TopInsetPadding` 组件：inset 为 null 或 ≤0 时原样返回 child，否则按 top 加 padding。
- `view.dart` / `app_bar_ani.dart`：顶部控件与弹幕都改用 `TopInsetPadding` 做避让。
- `pages/danmaku/view.dart`：弹幕可视高度同步减去 inset，弹幕轨道按缩小后的区域正确排布。
- `pages/video/view.dart`：把进全屏前捕获的 `_fixedTopInset` 传给播放器与弹幕。

## 生效范围

仅竖屏全屏生效；横屏全屏、非全屏、开启“移除安全边距”时均不避让。