### PR TITLE
fix: 修复 OHOS 上可选择文本跨行拖选跳变及自由复制窗口无法滚动

### DIFF
--- a/lib/common/widgets/selection_text.dart
+++ b/lib/common/widgets/selection_text.dart
@@ -1,14 +1,18 @@
 import 'package:PiliPlus/common/widgets/text_selection_toolbar.dart';
 import 'package:material_ui/material_ui.dart';
-import 'package:flutter/rendering.dart' show SelectedContent;
 
-class SelectionText extends StatefulWidget {
+/// 可选择文本的统一封装。
+///
+/// 内部走 [SelectableText]（EditableText/RenderEditable 路径）而非
+/// [SelectionArea]：OHOS Flutter fork 上 SelectionArea 长按拖选跨行会
+/// 跳变、光标无法停在行尾，且静态 Text 高度受限时无法滚动；
+/// SelectableText 按字符拖选、自带内部滚动,与输入框选择行为一致。
+class SelectionText extends StatelessWidget {
   const SelectionText(
     String this.data, {
     super.key,
     this.style,
     this.textAlign,
-    this.onSelectionChanged,
     this.contextMenuBuilder,
   }) : textSpan = null;
 
@@ -17,7 +21,6 @@ class SelectionText extends StatefulWidget {
     super.key,
     this.style,
     this.textAlign,
-    this.onSelectionChanged,
     this.contextMenuBuilder,
   }) : data = null;
 
@@ -26,46 +29,19 @@ class SelectionText extends StatefulWidget {
   final TextStyle? style;
   final TextAlign? textAlign;
 
-  /// 选中内容变化回调，可用于在自定义工具栏里获取当前选中文本。
-  final ValueChanged<SelectedContent?>? onSelectionChanged;
-  final SelectableRegionContextMenuBuilder? contextMenuBuilder;
-
-  @override
-  State<SelectionText> createState() => _SelectionTextState();
-}
-
-class _SelectionTextState extends State<SelectionText> {
-  SelectedContent? _lastContent;
+  /// 自定义上下文菜单；选中文本可从 [EditableTextState.textEditingValue] 读取。
+  final EditableTextContextMenuBuilder? contextMenuBuilder;
 
   @override
   Widget build(BuildContext context) {
-    return SelectionArea(
-      onSelectionChanged: (content) {
-        _lastContent = content;
-        widget.onSelectionChanged?.call(content);
-      },
-      contextMenuBuilder: widget.contextMenuBuilder ?? _defaultContextMenuBuilder,
-      child: Text.rich(
-        style: widget.style,
-        textAlign: widget.textAlign,
-        TextSpan(
-          text: widget.data,
-          children: widget.textSpan != null
-              ? <InlineSpan>[widget.textSpan!]
-              : null,
-        ),
+    return SelectableText.rich(
+      TextSpan(
+        text: data,
+        children: textSpan != null ? <InlineSpan>[textSpan!] : null,
       ),
-    );
-  }
-
-  Widget _defaultContextMenuBuilder(
-    BuildContext context,
-    SelectableRegionState selectableRegionState,
-  ) {
-    return selectionAreaContextMenuBuilder(
-      context,
-      selectableRegionState,
-      selectedTextOf: () => _lastContent?.plainText,
+      style: style,
+      textAlign: textAlign,
+      contextMenuBuilder: contextMenuBuilder ?? selectableTextContextMenuBuilder,
     );
   }
 }

--- a/lib/common/widgets/text_selection_toolbar.dart
+++ b/lib/common/widgets/text_selection_toolbar.dart
@@ -4,7 +4,6 @@ import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:PiliPlus/utils/share_utils.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart' show SelectedContent;
 import 'package:get/get.dart';
 
 /// 在选中工具栏「复制」后追加统一「分享」项（Android/iOS/OHOS，桌面端除外）。
@@ -104,24 +103,6 @@ List<ContextMenuButtonItem> ensureExtraButtons(
   );
 }
 
-/// [SelectionArea]/[SelectionText] 上下文菜单：默认按钮 + 统一分享 + 打开/站内搜索。
-/// 选中文本由使用方经 [selectedTextOf] 注入（OHOS 引擎未暴露选中文本）。
-Widget selectionAreaContextMenuBuilder(
-  BuildContext context,
-  SelectableRegionState selectableRegionState, {
-  String? Function()? selectedTextOf,
-}) {
-  final buttonItems = ensureExtraButtons(
-    selectableRegionState.contextMenuButtonItems,
-    selectedTextOf: selectedTextOf ?? () => null,
-    hideToolbar: () => selectableRegionState.hideToolbar(),
-  );
-  return AdaptiveTextSelectionToolbar.buttonItems(
-    anchors: selectableRegionState.contextMenuAnchors,
-    buttonItems: buttonItems,
-  );
-}
-
 /// 标准 [SelectableText] 上下文菜单（内部为只读 [EditableText]）。
 Widget selectableTextContextMenuBuilder(
   BuildContext context,
@@ -143,14 +124,4 @@ String? _selectedTextOf(EditableTextState state) {
   final TextSelection selection = state.textEditingValue.selection;
   if (!selection.isValid || selection.isCollapsed) return null;
   return selection.textInside(state.textEditingValue.text);
-}
-
-/// 捕获当前选中文本，供自定义上下文菜单使用。
-class SelectedContentCapture {
-  SelectedContent? _content;
-
-  String? get selectedText => _content?.plainText;
-
-  /// 挂到 [SelectionArea]/[SelectionText] 的 `onSelectionChanged`。
-  void onSelectionChanged(SelectedContent? content) => _content = content;
 }

--- a/lib/pages/dynamics/widgets/content_panel.dart
+++ b/lib/pages/dynamics/widgets/content_panel.dart
@@ -27,7 +27,6 @@ Widget content(
   final pics = moduleDynamic?.major?.opus?.pics;
   final text =
       moduleDynamic?.desc?.text ?? moduleDynamic?.major?.opus?.summary?.text;
-  final capture = SelectedContentCapture();
   return Padding(
     padding: floor == 1
         ? const EdgeInsets.fromLTRB(12, 0, 12, 6)
@@ -78,10 +77,9 @@ Widget content(
                   style: isSave
                       ? const TextStyle(fontSize: 15)
                       : const TextStyle(fontSize: 16),
-                  onSelectionChanged: capture.onSelectionChanged,
                   contextMenuBuilder: text == null || text.isEmpty
                       ? null
-                      : (_, state) => _contextMenuBuilder(state, text, capture),
+                      : (_, state) => _contextMenuBuilder(state, text),
                 )
               : custom_text.Text.rich(
                   style: floor == 1
@@ -112,13 +110,19 @@ Widget content(
 }
 
 Widget _contextMenuBuilder(
-  SelectableRegionState state,
+  EditableTextState state,
   String text,
-  SelectedContentCapture capture,
 ) {
+  String? selectedText() {
+    final TextEditingValue value = state.textEditingValue;
+    final TextSelection selection = value.selection;
+    if (!selection.isValid || selection.isCollapsed) return null;
+    return selection.textInside(value.text);
+  }
+
   final buttonItems = ensureExtraButtons(
     state.contextMenuButtonItems,
-    selectedTextOf: () => capture.selectedText,
+    selectedTextOf: selectedText,
     hideToolbar: () => state.hideToolbar(),
   )..add(
     ContextMenuButtonItem(label: '文本', onPressed: () => _onCopyText(text)),
@@ -133,6 +137,7 @@ void _onCopyText(String text) {
   showDialog(
     context: Get.context!,
     builder: (context) => Dialog(
+      constraints: const BoxConstraints.tightFor(width: 380),
       child: Padding(
         padding: const .symmetric(horizontal: 20, vertical: 16),
         child: SelectionText(

--- a/lib/pages/setting/models/privacy_settings.dart
+++ b/lib/pages/setting/models/privacy_settings.dart
@@ -1,4 +1,4 @@
-import 'package:PiliPlus/common/widgets/text_selection_toolbar.dart';
+import 'package:PiliPlus/common/widgets/selection_text.dart';
 import 'package:PiliPlus/models/common/account_type.dart';
 import 'package:PiliPlus/pages/setting/models/model.dart';
 import 'package:PiliPlus/utils/accounts.dart';
@@ -26,22 +26,8 @@ List<SettingsModel> get privacySettings => [
         context: context,
         builder: (context) => AlertDialog(
           title: const Text('账号模式详情'),
-          content: Builder(
-            builder: (context) {
-              final capture = SelectedContentCapture();
-              return SelectionArea(
-                onSelectionChanged: capture.onSelectionChanged,
-                contextMenuBuilder: (context, state) =>
-                    selectionAreaContextMenuBuilder(
-                  context,
-                  state,
-                  selectedTextOf: () => capture.selectedText,
-                ),
-                child: SingleChildScrollView(
-                  child: _getAccountDetail(context),
-                ),
-              );
-            },
+          content: SingleChildScrollView(
+            child: _getAccountDetail(context),
           ),
           actions: [
             TextButton(
@@ -67,7 +53,7 @@ Widget _getAccountDetail(BuildContext context) {
 
     slivers
       ..add(Center(child: Text(i.title, style: theme.titleMedium)))
-      ..add(Text(url.join('\n')));
+      ..add(SelectionText(url.join('\n')));
   }
   return Column(
     mainAxisSize: MainAxisSize.min,

--- a/lib/pages/video/reply/widgets/reply_item_grpc.dart
+++ b/lib/pages/video/reply/widgets/reply_item_grpc.dart
@@ -13,7 +13,6 @@ import 'package:PiliPlus/common/widgets/gesture/tap_gesture_recognizer.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/image_grid/image_grid_view.dart';
 import 'package:PiliPlus/common/widgets/pendant_avatar.dart';
-import 'package:PiliPlus/common/widgets/selection_text.dart';
 import 'package:PiliPlus/common/widgets/text_selection_toolbar.dart';
 import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
     show ReplyInfo, ReplyControl, Content, Url, ReplyControl_VoteOption;
@@ -1200,19 +1199,17 @@ class ReplyItemGrpc extends StatelessWidget {
               showDialog(
                 context: context,
                 builder: (context) => Dialog(
+                  constraints: const BoxConstraints.tightFor(width: 380),
                   child: Padding(
                     padding: const .symmetric(horizontal: 20, vertical: 16),
-                    child: Builder(
-                      builder: (context) {
-                        final capture = SelectedContentCapture();
-                        return SelectionText(
-                          message,
-                          style: const TextStyle(fontSize: 15, height: 1.7),
-                          onSelectionChanged: capture.onSelectionChanged,
-                          contextMenuBuilder: (_, state) =>
-                              _filterMenuBuilder(context, state, capture),
-                        );
-                      },
+                    // OHOS 引擎上 SelectionArea 长按拖选跨行会跳变，
+                    // 这里沿用 EditableText 路径的 SelectableText（按字符拖选、
+                    // 高度受限时自带滚动），行为与上游 Android 端一致。
+                    child: SelectableText(
+                      message,
+                      style: const TextStyle(fontSize: 15, height: 1.7),
+                      contextMenuBuilder: (_, state) =>
+                          _filterMenuBuilder(context, state),
                     ),
                   ),
                 ),
@@ -1248,15 +1245,21 @@ class ReplyItemGrpc extends StatelessWidget {
 
   static Widget _filterMenuBuilder(
     BuildContext context,
-    SelectableRegionState selectableRegionState,
-    SelectedContentCapture capture,
+    EditableTextState editableTextState,
   ) {
+    String? selectedText() {
+      final TextEditingValue value = editableTextState.textEditingValue;
+      final TextSelection selection = value.selection;
+      if (!selection.isValid || selection.isCollapsed) return null;
+      return selection.textInside(value.text);
+    }
+
     final items = ensureExtraButtons(
-      selectableRegionState.contextMenuButtonItems,
-      selectedTextOf: () => capture.selectedText,
-      hideToolbar: () => selectableRegionState.hideToolbar(),
+      editableTextState.contextMenuButtonItems,
+      selectedTextOf: selectedText,
+      hideToolbar: () => editableTextState.hideToolbar(),
     );
-    final String? selected = capture.selectedText;
+    final String? selected = selectedText();
     if (selected != null && selected.isNotEmpty) {
       items.add(
         ContextMenuButtonItem(
@@ -1297,7 +1300,7 @@ class ReplyItemGrpc extends StatelessWidget {
     }
     return AdaptiveTextSelectionToolbar.buttonItems(
       buttonItems: items,
-      anchors: selectableRegionState.contextMenuAnchors,
+      anchors: editableTextState.contextMenuAnchors,
     );
   }
 }

--- a/lib/pages/video/reply/widgets/reply_item_grpc.dart
+++ b/lib/pages/video/reply/widgets/reply_item_grpc.dart
@@ -13,6 +13,7 @@ import 'package:PiliPlus/common/widgets/gesture/tap_gesture_recognizer.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/image_grid/image_grid_view.dart';
 import 'package:PiliPlus/common/widgets/pendant_avatar.dart';
+import 'package:PiliPlus/common/widgets/selection_text.dart';
 import 'package:PiliPlus/common/widgets/text_selection_toolbar.dart';
 import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
     show ReplyInfo, ReplyControl, Content, Url, ReplyControl_VoteOption;
@@ -1202,10 +1203,7 @@ class ReplyItemGrpc extends StatelessWidget {
                   constraints: const BoxConstraints.tightFor(width: 380),
                   child: Padding(
                     padding: const .symmetric(horizontal: 20, vertical: 16),
-                    // OHOS 引擎上 SelectionArea 长按拖选跨行会跳变，
-                    // 这里沿用 EditableText 路径的 SelectableText（按字符拖选、
-                    // 高度受限时自带滚动），行为与上游 Android 端一致。
-                    child: SelectableText(
+                    child: SelectionText(
                       message,
                       style: const TextStyle(fontSize: 15, height: 1.7),
                       contextMenuBuilder: (_, state) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
 # update when release
-version: 2.1.2+5892
+version: 2.1.2+5894
 
 environment:
   sdk: ">=3.11.1"


### PR DESCRIPTION
## 问题

评论区长按 → 「自由复制」弹出的文本窗口存在两个问题(均为 OHOS 分支特有,上游 Android 端不存在):

1. **跨行拖选跳变**:长按选词后拖动,选区边缘从第一行跨到第二行时出现明显跳变,轻微拖动就会把第二行及之后的全部文字选中;且选区结束光标永远无法停在第一行末尾,最好情况只能落在第二行开头。
2. **长文本无法滚动**:评论较长、当前窗口展示不下时,无法滑动查看后面的文字。

同样的跨行拖选问题存在于所有经 `SelectionText` 封装的可选择文本处(动态正文、视频简介、私信、SuperChat、日志页等)。

## 原因

同步上游 2.1.1 时,可选择文本跟随上游从 `SelectableText` 换成了 `SelectionArea`(`SelectionText` 封装)。上游在标准 Flutter 上无异常,但 OHOS Flutter fork(3.41.10-ohos)上该路径有缺陷:

- `SelectionArea` 长按拖选走 `RenderParagraph` selectable fragment 的 word 粒度边界逻辑。fork 中 `widgets/selectable_region.dart` 已更新到 3.41.3,而 `rendering/paragraph.dart` 仍停留在 3.35 版本,两层实现不匹配,拖选边缘跨行时按词边界扩展出现大幅跳选,且光标 affinity 处理缺陷导致无法停在视觉行末尾。
- 自由复制窗口较上游实现缺少 `SingleChildScrollView`,超出窗口高度的文本直接被截断。

## 修改

**核心:`SelectionText` 封装内部由 `SelectionArea` 单点切回 `SelectableText`**(EditableText/RenderEditable 路径,与输入框选择同一套代码,按字符拖选无跳变;高度受限时自带内部滚动),即本分支同步 2.1.1 之前验证可用的旧方案。所有 `SelectionText`/`SelectionText.rich` 使用处(约 20 处)自动获得修复,调用方 API 不变。

- `lib/common/widgets/selection_text.dart`:重写为 `SelectableText.rich` 封装;`contextMenuBuilder` 类型相应从 `SelectableRegionContextMenuBuilder` 改为 `EditableTextContextMenuBuilder`,默认菜单走既有的 `selectableTextContextMenuBuilder`(复制/分享/站内搜索),不再需要 `onSelectionChanged` + `SelectedContentCapture` 捕获机制(选中文本直接从 `EditableTextState.textEditingValue` 读取)。
- `lib/pages/video/reply/widgets/reply_item_grpc.dart`:自由复制窗口沿用 `SelectionText`(现为 SelectableText 路径,长文本可内部滚动);`_filterMenuBuilder` 改接 `EditableTextState`;补上与上游一致的窗口宽度约束 `BoxConstraints.tightFor(width: 380)`。
- `lib/pages/dynamics/widgets/content_panel.dart`:动态正文自定义菜单同步改接 `EditableTextState`;动态「文本」窗口补同款宽度约束。
- `lib/pages/setting/models/privacy_settings.dart`:「账号模式详情」对话框由裸 `SelectionArea` 包整棵树改为各 API 列表块内使用 `SelectionText`(布局不变,选择在块内进行)。
- `lib/common/widgets/text_selection_toolbar.dart`:移除不再有使用方的 `selectionAreaContextMenuBuilder` 与 `SelectedContentCapture`,避免后续误用回问题路径。

## 备注

`ai_conclusion`、`article`、`log_table` 三处为真正的跨组件选择场景(整页 CustomScrollView / 表格行),只能继续使用 `SelectionArea`,在 OHOS 上仍受跨行拖选跳变影响;该问题根因在 fork SDK 两层版本不匹配,待 fork 的 `rendering/paragraph.dart` 同步到 3.41 后有望自,应用层不做侵入式处理。
